### PR TITLE
Support adding arguments in the errorMessage for custom constraints

### DIFF
--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -65,6 +65,7 @@ import am.ik.yavi.core.NestedValidatorSubset;
 import am.ik.yavi.core.NullAs;
 import am.ik.yavi.core.Validator;
 import am.ik.yavi.core.ValidatorSubset;
+import am.ik.yavi.core.ViolatedArguments;
 import am.ik.yavi.core.ViolationMessage;
 import am.ik.yavi.fn.Pair;
 import am.ik.yavi.message.MessageFormatter;
@@ -277,13 +278,19 @@ public class ValidatorBuilder<T> {
 	}
 
 	public ValidatorBuilder<T> constraintOnTarget(Predicate<T> predicate, String name,
-			ViolationMessage violationMessage) {
+			ViolatedArguments violatedArguments, ViolationMessage violationMessage) {
 		Deque<ConstraintPredicate<T>> predicates = new LinkedList<>();
 		predicates.add(ConstraintPredicate.of(predicate, violationMessage,
-				() -> new Object[] { name }, NullAs.INVALID));
+				violatedArguments::arguments, NullAs.INVALID));
 		this.predicatesList
 				.add(new ConstraintPredicates<>(Function.identity(), name, predicates));
 		return this;
+	}
+
+	public ValidatorBuilder<T> constraintOnTarget(Predicate<T> predicate, String name,
+			ViolationMessage violationMessage) {
+		return this.constraintOnTarget(predicate, name,
+				() -> CustomConstraint.EMPTY_ARRAY, violationMessage);
 	}
 
 	public ValidatorBuilder<T> constraintOnTarget(Predicate<T> predicate, String name,
@@ -294,7 +301,8 @@ public class ValidatorBuilder<T> {
 
 	public ValidatorBuilder<T> constraintOnTarget(CustomConstraint<T> customConstraint,
 			String name) {
-		return this.constraintOnTarget(customConstraint, name, customConstraint);
+		return this.constraintOnTarget(customConstraint, name, customConstraint,
+				customConstraint);
 	}
 
 	public <L extends Collection<E>, E> ValidatorBuilder<T> forEach(

--- a/src/main/java/am/ik/yavi/core/ViolatedArguments.java
+++ b/src/main/java/am/ik/yavi/core/ViolatedArguments.java
@@ -15,16 +15,16 @@
  */
 package am.ik.yavi.core;
 
-import java.util.Objects;
-import java.util.function.Predicate;
+public interface ViolatedArguments {
 
-public interface CustomConstraint<V>
-		extends Predicate<V>, ViolationMessage, ViolatedArguments {
-
-	Objects[] EMPTY_ARRAY = new Objects[0];
-
-	@Override
-	default Object[] arguments() {
-		return EMPTY_ARRAY;
-	}
+	/**
+	 * returns arguments that can be used to build the violation message<br>
+	 * The argument can be access by <code>{1}</code>, <code>{2}</code> , .... <br>
+	 * Note that <code>{0}</code> is reserved for the property name and the last index in
+	 * reserved for the actual value.<br>
+	 * The implementer don't need to include the property name and the actual value.
+	 * 
+	 * @return the array of arguments
+	 */
+	Object[] arguments();
 }


### PR DESCRIPTION
closes #36

This pr adds `ViolatedArguments` interface to support custom arguments that can be used in the error message for a custom constaint.

@night-crawler
Can you please take a look at the changes and see it works for you?
 