### PR TITLE
Ability to i18n ViolationMessages

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/BooleanConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BooleanConstraint.java
@@ -21,22 +21,27 @@ import am.ik.yavi.core.IncludedViolationMessages;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class BooleanConstraint<T> extends ConstraintBase<T, Boolean, BooleanConstraint<T>> {
+public class BooleanConstraint<T>
+		extends ConstraintBase<T, Boolean, BooleanConstraint<T>> {
 
-    @Override
-    public BooleanConstraint<T> cast() {
-        return this;
-    }
+	@Override
+	public BooleanConstraint<T> cast() {
+		return this;
+	}
 
-    public BooleanConstraint<T> isFalse() {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> !x, IncludedViolationMessages.get().BOOLEAN_IS_FALSE(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public BooleanConstraint<T> isFalse() {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> !x,
+						IncludedViolationMessages.get().BOOLEAN_IS_FALSE(),
+						() -> new Object[] {}, VALID));
+		return this;
+	}
 
-    public BooleanConstraint<T> isTrue() {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> x, IncludedViolationMessages.get().BOOLEAN_IS_TRUE(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public BooleanConstraint<T> isTrue() {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x,
+						IncludedViolationMessages.get().BOOLEAN_IS_TRUE(),
+						() -> new Object[] {}, VALID));
+		return this;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/BooleanConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BooleanConstraint.java
@@ -15,30 +15,28 @@
  */
 package am.ik.yavi.constraint;
 
-import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.BOOLEAN_IS_FALSE;
-import static am.ik.yavi.core.ViolationMessage.Default.BOOLEAN_IS_TRUE;
-
 import am.ik.yavi.constraint.base.ConstraintBase;
 import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
 
-public class BooleanConstraint<T>
-		extends ConstraintBase<T, Boolean, BooleanConstraint<T>> {
+import static am.ik.yavi.core.NullAs.VALID;
 
-	@Override
-	public BooleanConstraint<T> cast() {
-		return this;
-	}
+public class BooleanConstraint<T> extends ConstraintBase<T, Boolean, BooleanConstraint<T>> {
 
-	public BooleanConstraint<T> isFalse() {
-		this.predicates().add(ConstraintPredicate.of(x -> !x, BOOLEAN_IS_FALSE,
-				() -> new Object[] {}, VALID));
-		return this;
-	}
+    @Override
+    public BooleanConstraint<T> cast() {
+        return this;
+    }
 
-	public BooleanConstraint<T> isTrue() {
-		this.predicates().add(ConstraintPredicate.of(x -> x, BOOLEAN_IS_TRUE,
-				() -> new Object[] {}, VALID));
-		return this;
-	}
+    public BooleanConstraint<T> isFalse() {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> !x, IncludedViolationMessages.get().BOOLEAN_IS_FALSE(), () -> new Object[]{}, VALID));
+        return this;
+    }
+
+    public BooleanConstraint<T> isTrue() {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> x, IncludedViolationMessages.get().BOOLEAN_IS_TRUE(), () -> new Object[]{}, VALID));
+        return this;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -45,147 +45,160 @@ import static am.ik.yavi.core.NullAs.INVALID;
 import static am.ik.yavi.core.NullAs.VALID;
 
 public class CharSequenceConstraint<T, E extends CharSequence>
-        extends ContainerConstraintBase<T, E, CharSequenceConstraint<T, E>> {
+		extends ContainerConstraintBase<T, E, CharSequenceConstraint<T, E>> {
 
-    private static final String EMAIL_PART = "[^\\x00-\\x1F()<>@,;:\\\\\".\\[\\]\\s]";
-    private static final String DOMAIN_PATTERN = EMAIL_PART + "+(\\." + EMAIL_PART + "+)*";
-    private static final String IPv4_PATTERN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
-    public static final Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern.compile(
-            "^" + EMAIL_PART + "+(\\." + EMAIL_PART + "+)*@(" + DOMAIN_PATTERN + "|" + IPv4_PATTERN + ")$",
-            Pattern.CASE_INSENSITIVE);
-    protected final Normalizer.Form normalizerForm;
-    protected final VariantOptions variantOptions;
+	private static final String EMAIL_PART = "[^\\x00-\\x1F()<>@,;:\\\\\".\\[\\]\\s]";
+	private static final String DOMAIN_PATTERN = EMAIL_PART + "+(\\." + EMAIL_PART
+			+ "+)*";
+	private static final String IPv4_PATTERN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
+	public static final Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern
+			.compile("^" + EMAIL_PART + "+(\\." + EMAIL_PART + "+)*@(" + DOMAIN_PATTERN
+					+ "|" + IPv4_PATTERN + ")$", Pattern.CASE_INSENSITIVE);
+	protected final Normalizer.Form normalizerForm;
+	protected final VariantOptions variantOptions;
 
-    public CharSequenceConstraint() {
-        this(Normalizer.Form.NFC, VariantOptions.builder().build());
-    }
+	public CharSequenceConstraint() {
+		this(Normalizer.Form.NFC, VariantOptions.builder().build());
+	}
 
-    public CharSequenceConstraint(Normalizer.Form normalizerForm, VariantOptions variantOptions) {
-        this.normalizerForm = normalizerForm;
-        this.variantOptions = variantOptions;
-    }
+	public CharSequenceConstraint(Normalizer.Form normalizerForm,
+			VariantOptions variantOptions) {
+		this.normalizerForm = normalizerForm;
+		this.variantOptions = variantOptions;
+	}
 
-    public ByteSizeConstraint<T, E> asByteArray() {
-        return this.asByteArray(StandardCharsets.UTF_8);
-    }
+	public ByteSizeConstraint<T, E> asByteArray() {
+		return this.asByteArray(StandardCharsets.UTF_8);
+	}
 
-    public ByteSizeConstraint<T, E> asByteArray(Charset charset) {
-        return new ByteSizeConstraint<>(this, charset);
-    }
+	public ByteSizeConstraint<T, E> asByteArray(Charset charset) {
+		return new ByteSizeConstraint<>(this, charset);
+	}
 
-    @Override
-    public CharSequenceConstraint<T, E> cast() {
-        return this;
-    }
+	@Override
+	public CharSequenceConstraint<T, E> cast() {
+		return this;
+	}
 
-    public CodePointsConstraint.Builder<T, E> codePoints(Set<Integer> allowedCodePoints) {
-        return this.codePoints((CodePointsSet<E>) () -> allowedCodePoints);
-    }
+	public CodePointsConstraint.Builder<T, E> codePoints(Set<Integer> allowedCodePoints) {
+		return this.codePoints((CodePointsSet<E>) () -> allowedCodePoints);
+	}
 
-    public CodePointsConstraint.Builder<T, E> codePoints(CodePoints<E> codePoints) {
-        return new CodePointsConstraint.Builder<>(this, codePoints);
-    }
+	public CodePointsConstraint.Builder<T, E> codePoints(CodePoints<E> codePoints) {
+		return new CodePointsConstraint.Builder<>(this, codePoints);
+	}
 
-    public CodePointsConstraint.Builder<T, E> codePoints(int begin, int end) {
-        return this.codePoints(Range.of(begin, end));
-    }
+	public CodePointsConstraint.Builder<T, E> codePoints(int begin, int end) {
+		return this.codePoints(Range.of(begin, end));
+	}
 
-    public CodePointsConstraint.Builder<T, E> codePoints(Range range, Range... ranges) {
-        return this.codePoints((CodePointsRanges<E>) () -> {
-            List<Range> list = new ArrayList<>();
-            list.add(range);
-            list.addAll(Arrays.asList(ranges));
-            return list;
-        });
-    }
+	public CodePointsConstraint.Builder<T, E> codePoints(Range range, Range... ranges) {
+		return this.codePoints((CodePointsRanges<E>) () -> {
+			List<Range> list = new ArrayList<>();
+			list.add(range);
+			list.addAll(Arrays.asList(ranges));
+			return list;
+		});
+	}
 
-    public CharSequenceConstraint<T, E> contains(CharSequence s) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> x.toString().contains(s), DefaultIncludedViolationMessages.get().CHAR_SEQUENCE_CONTAINS(),
-                        () -> new Object[]{s}, VALID));
-        return this;
-    }
+	public CharSequenceConstraint<T, E> contains(CharSequence s) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.toString().contains(s),
+						DefaultIncludedViolationMessages.get().CHAR_SEQUENCE_CONTAINS(),
+						() -> new Object[] { s }, VALID));
+		return this;
+	}
 
-    public CharSequenceConstraint<T, E> email() {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            if (size().applyAsInt(x) == 0) {
-                return true;
-            }
-            return VALID_EMAIL_ADDRESS_REGEX.matcher(x).matches();
-        }, IncludedViolationMessages.get().CHAR_SEQUENCE_EMAIL(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public CharSequenceConstraint<T, E> email() {
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			if (size().applyAsInt(x) == 0) {
+				return true;
+			}
+			return VALID_EMAIL_ADDRESS_REGEX.matcher(x).matches();
+		}, IncludedViolationMessages.get().CHAR_SEQUENCE_EMAIL(), () -> new Object[] {},
+				VALID));
+		return this;
+	}
 
-    @Override
-    protected ToIntFunction<E> size() {
-        return cs -> {
-            String s = this.normalize(cs.toString());
-            return s.codePointCount(0, s.length());
-        };
-    }
+	@Override
+	protected ToIntFunction<E> size() {
+		return cs -> {
+			String s = this.normalize(cs.toString());
+			return s.codePointCount(0, s.length());
+		};
+	}
 
-    protected String normalize(String s) {
-        String str = this.variantOptions.ignored(s);
-        return this.normalizerForm == null ? str : Normalizer.normalize(str, this.normalizerForm);
-    }
+	protected String normalize(String s) {
+		String str = this.variantOptions.ignored(s);
+		return this.normalizerForm == null ? str
+				: Normalizer.normalize(str, this.normalizerForm);
+	}
 
-    public EmojiConstraint<T, E> emoji() {
-        return new EmojiConstraint<>(this, this.normalizerForm, this.variantOptions);
-    }
+	public EmojiConstraint<T, E> emoji() {
+		return new EmojiConstraint<>(this, this.normalizerForm, this.variantOptions);
+	}
 
-    public CharSequenceConstraint<T, E> normalizer(Normalizer.Form normalizerForm) {
-        CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(normalizerForm, this.variantOptions);
-        constraint.predicates().addAll(this.predicates());
-        return constraint;
-    }
+	public CharSequenceConstraint<T, E> normalizer(Normalizer.Form normalizerForm) {
+		CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(
+				normalizerForm, this.variantOptions);
+		constraint.predicates().addAll(this.predicates());
+		return constraint;
+	}
 
-    public CharSequenceConstraint<T, E> notBlank() {
-        this.predicates().add(ConstraintPredicate.of(x -> x != null && trim(x.toString()).length() != 0,
-                IncludedViolationMessages.get().CHAR_SEQUENCE_NOT_BLANK(), () -> new Object[]{}, INVALID));
-        return this;
-    }
+	public CharSequenceConstraint<T, E> notBlank() {
+		this.predicates()
+				.add(ConstraintPredicate.of(
+						x -> x != null && trim(x.toString()).length() != 0,
+						IncludedViolationMessages.get().CHAR_SEQUENCE_NOT_BLANK(),
+						() -> new Object[] {}, INVALID));
+		return this;
+	}
 
-    private static String trim(String s) {
-        if (s.length() == 0) {
-            return s;
-        }
-        StringBuilder sb = new StringBuilder(s);
-        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
-            sb.deleteCharAt(0);
-        }
-        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
-            sb.deleteCharAt(sb.length() - 1);
-        }
-        return sb.toString();
-    }
+	private static String trim(String s) {
+		if (s.length() == 0) {
+			return s;
+		}
+		StringBuilder sb = new StringBuilder(s);
+		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
+			sb.deleteCharAt(0);
+		}
+		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
+			sb.deleteCharAt(sb.length() - 1);
+		}
+		return sb.toString();
+	}
 
-    public CharSequenceConstraint<T, E> pattern(String regex) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> Pattern.matches(regex, x), IncludedViolationMessages.get().CHAR_SEQUENCE_PATTERN(),
-                        () -> new Object[]{regex}, VALID));
-        return this;
-    }
+	public CharSequenceConstraint<T, E> pattern(String regex) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> Pattern.matches(regex, x),
+						IncludedViolationMessages.get().CHAR_SEQUENCE_PATTERN(),
+						() -> new Object[] { regex }, VALID));
+		return this;
+	}
 
-    public CharSequenceConstraint<T, E> url() {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            if (size().applyAsInt(x) == 0) {
-                return true;
-            }
-            try {
-                new URL(x.toString());
-                return true;
-            } catch (MalformedURLException e) {
-                return false;
-            }
-        }, IncludedViolationMessages.get().CHAR_SEQUENCE_URL(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public CharSequenceConstraint<T, E> url() {
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			if (size().applyAsInt(x) == 0) {
+				return true;
+			}
+			try {
+				new URL(x.toString());
+				return true;
+			}
+			catch (MalformedURLException e) {
+				return false;
+			}
+		}, IncludedViolationMessages.get().CHAR_SEQUENCE_URL(), () -> new Object[] {},
+				VALID));
+		return this;
+	}
 
-    public CharSequenceConstraint<T, E> variant(Function<VariantOptions.Builder, VariantOptions.Builder> opts) {
-        VariantOptions.Builder builder = VariantOptions.builder();
-        CharSequenceConstraint<T, E> constraint =
-                new CharSequenceConstraint<>(this.normalizerForm, opts.apply(builder).build());
-        constraint.predicates().addAll(this.predicates());
-        return constraint;
-    }
+	public CharSequenceConstraint<T, E> variant(
+			Function<VariantOptions.Builder, VariantOptions.Builder> opts) {
+		VariantOptions.Builder builder = VariantOptions.builder();
+		CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(
+				this.normalizerForm, opts.apply(builder).build());
+		constraint.predicates().addAll(this.predicates());
+		return constraint;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -15,6 +15,19 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.constraint.charsequence.ByteSizeConstraint;
+import am.ik.yavi.constraint.charsequence.CodePoints;
+import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsRanges;
+import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
+import am.ik.yavi.constraint.charsequence.CodePoints.Range;
+import am.ik.yavi.constraint.charsequence.CodePointsConstraint;
+import am.ik.yavi.constraint.charsequence.EmojiConstraint;
+import am.ik.yavi.constraint.charsequence.variant.VariantOptions;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.DefaultIncludedViolationMessages;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -30,171 +43,149 @@ import java.util.regex.Pattern;
 
 import static am.ik.yavi.core.NullAs.INVALID;
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.CHAR_SEQUENCE_CONTAINS;
-import static am.ik.yavi.core.ViolationMessage.Default.CHAR_SEQUENCE_EMAIL;
-import static am.ik.yavi.core.ViolationMessage.Default.CHAR_SEQUENCE_NOT_BLANK;
-import static am.ik.yavi.core.ViolationMessage.Default.CHAR_SEQUENCE_PATTERN;
-import static am.ik.yavi.core.ViolationMessage.Default.CHAR_SEQUENCE_URL;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.constraint.charsequence.ByteSizeConstraint;
-import am.ik.yavi.constraint.charsequence.CodePoints;
-import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsRanges;
-import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
-import am.ik.yavi.constraint.charsequence.CodePoints.Range;
-import am.ik.yavi.constraint.charsequence.CodePointsConstraint;
-import am.ik.yavi.constraint.charsequence.EmojiConstraint;
-import am.ik.yavi.constraint.charsequence.variant.VariantOptions;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class CharSequenceConstraint<T, E extends CharSequence>
-		extends ContainerConstraintBase<T, E, CharSequenceConstraint<T, E>> {
-	private static final String EMAIL_PART = "[^\\x00-\\x1F()<>@,;:\\\\\".\\[\\]\\s]";
-	private static final String DOMAIN_PATTERN = EMAIL_PART + "+(\\." + EMAIL_PART
-			+ "+)*";
-	private static final String IPv4_PATTERN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
-	public static final Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern
-			.compile("^" + EMAIL_PART + "+(\\." + EMAIL_PART + "+)*@(" + DOMAIN_PATTERN
-					+ "|" + IPv4_PATTERN + ")$", Pattern.CASE_INSENSITIVE);
+        extends ContainerConstraintBase<T, E, CharSequenceConstraint<T, E>> {
 
-	protected final Normalizer.Form normalizerForm;
-	protected final VariantOptions variantOptions;
+    private static final String EMAIL_PART = "[^\\x00-\\x1F()<>@,;:\\\\\".\\[\\]\\s]";
+    private static final String DOMAIN_PATTERN = EMAIL_PART + "+(\\." + EMAIL_PART + "+)*";
+    private static final String IPv4_PATTERN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
+    public static final Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern.compile(
+            "^" + EMAIL_PART + "+(\\." + EMAIL_PART + "+)*@(" + DOMAIN_PATTERN + "|" + IPv4_PATTERN + ")$",
+            Pattern.CASE_INSENSITIVE);
+    protected final Normalizer.Form normalizerForm;
+    protected final VariantOptions variantOptions;
 
-	public CharSequenceConstraint() {
-		this(Normalizer.Form.NFC, VariantOptions.builder().build());
-	}
+    public CharSequenceConstraint() {
+        this(Normalizer.Form.NFC, VariantOptions.builder().build());
+    }
 
-	public CharSequenceConstraint(Normalizer.Form normalizerForm,
-			VariantOptions variantOptions) {
-		this.normalizerForm = normalizerForm;
-		this.variantOptions = variantOptions;
-	}
+    public CharSequenceConstraint(Normalizer.Form normalizerForm, VariantOptions variantOptions) {
+        this.normalizerForm = normalizerForm;
+        this.variantOptions = variantOptions;
+    }
 
-	public ByteSizeConstraint<T, E> asByteArray(Charset charset) {
-		return new ByteSizeConstraint<>(this, charset);
-	}
+    public ByteSizeConstraint<T, E> asByteArray() {
+        return this.asByteArray(StandardCharsets.UTF_8);
+    }
 
-	public ByteSizeConstraint<T, E> asByteArray() {
-		return this.asByteArray(StandardCharsets.UTF_8);
-	}
+    public ByteSizeConstraint<T, E> asByteArray(Charset charset) {
+        return new ByteSizeConstraint<>(this, charset);
+    }
 
-	@Override
-	public CharSequenceConstraint<T, E> cast() {
-		return this;
-	}
+    @Override
+    public CharSequenceConstraint<T, E> cast() {
+        return this;
+    }
 
-	public CodePointsConstraint.Builder<T, E> codePoints(CodePoints<E> codePoints) {
-		return new CodePointsConstraint.Builder<>(this, codePoints);
-	}
+    public CodePointsConstraint.Builder<T, E> codePoints(Set<Integer> allowedCodePoints) {
+        return this.codePoints((CodePointsSet<E>) () -> allowedCodePoints);
+    }
 
-	public CodePointsConstraint.Builder<T, E> codePoints(Set<Integer> allowedCodePoints) {
-		return this.codePoints((CodePointsSet<E>) () -> allowedCodePoints);
-	}
+    public CodePointsConstraint.Builder<T, E> codePoints(CodePoints<E> codePoints) {
+        return new CodePointsConstraint.Builder<>(this, codePoints);
+    }
 
-	public CodePointsConstraint.Builder<T, E> codePoints(int begin, int end) {
-		return this.codePoints(Range.of(begin, end));
-	}
+    public CodePointsConstraint.Builder<T, E> codePoints(int begin, int end) {
+        return this.codePoints(Range.of(begin, end));
+    }
 
-	public CodePointsConstraint.Builder<T, E> codePoints(Range range, Range... ranges) {
-		return this.codePoints((CodePointsRanges<E>) () -> {
-			List<Range> list = new ArrayList<>();
-			list.add(range);
-			list.addAll(Arrays.asList(ranges));
-			return list;
-		});
-	}
+    public CodePointsConstraint.Builder<T, E> codePoints(Range range, Range... ranges) {
+        return this.codePoints((CodePointsRanges<E>) () -> {
+            List<Range> list = new ArrayList<>();
+            list.add(range);
+            list.addAll(Arrays.asList(ranges));
+            return list;
+        });
+    }
 
-	public CharSequenceConstraint<T, E> contains(CharSequence s) {
-		this.predicates().add(ConstraintPredicate.of(x -> x.toString().contains(s),
-				CHAR_SEQUENCE_CONTAINS, () -> new Object[] { s }, VALID));
-		return this;
-	}
+    public CharSequenceConstraint<T, E> contains(CharSequence s) {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> x.toString().contains(s), DefaultIncludedViolationMessages.get().CHAR_SEQUENCE_CONTAINS(),
+                        () -> new Object[]{s}, VALID));
+        return this;
+    }
 
-	public CharSequenceConstraint<T, E> email() {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			if (size().applyAsInt(x) == 0) {
-				return true;
-			}
-			return VALID_EMAIL_ADDRESS_REGEX.matcher(x).matches();
-		}, CHAR_SEQUENCE_EMAIL, () -> new Object[] {}, VALID));
-		return this;
-	}
+    public CharSequenceConstraint<T, E> email() {
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            if (size().applyAsInt(x) == 0) {
+                return true;
+            }
+            return VALID_EMAIL_ADDRESS_REGEX.matcher(x).matches();
+        }, IncludedViolationMessages.get().CHAR_SEQUENCE_EMAIL(), () -> new Object[]{}, VALID));
+        return this;
+    }
 
-	public EmojiConstraint<T, E> emoji() {
-		return new EmojiConstraint<>(this, this.normalizerForm, this.variantOptions);
-	}
+    @Override
+    protected ToIntFunction<E> size() {
+        return cs -> {
+            String s = this.normalize(cs.toString());
+            return s.codePointCount(0, s.length());
+        };
+    }
 
-	public CharSequenceConstraint<T, E> normalizer(Normalizer.Form normalizerForm) {
-		CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(
-				normalizerForm, this.variantOptions);
-		constraint.predicates().addAll(this.predicates());
-		return constraint;
-	}
+    protected String normalize(String s) {
+        String str = this.variantOptions.ignored(s);
+        return this.normalizerForm == null ? str : Normalizer.normalize(str, this.normalizerForm);
+    }
 
-	public CharSequenceConstraint<T, E> notBlank() {
-		this.predicates()
-				.add(ConstraintPredicate.of(
-						x -> x != null && trim(x.toString()).length() != 0,
-						CHAR_SEQUENCE_NOT_BLANK, () -> new Object[] {}, INVALID));
-		return this;
-	}
+    public EmojiConstraint<T, E> emoji() {
+        return new EmojiConstraint<>(this, this.normalizerForm, this.variantOptions);
+    }
 
-	public CharSequenceConstraint<T, E> pattern(String regex) {
-		this.predicates().add(ConstraintPredicate.of(x -> Pattern.matches(regex, x),
-				CHAR_SEQUENCE_PATTERN, () -> new Object[] { regex }, VALID));
-		return this;
-	}
+    public CharSequenceConstraint<T, E> normalizer(Normalizer.Form normalizerForm) {
+        CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(normalizerForm, this.variantOptions);
+        constraint.predicates().addAll(this.predicates());
+        return constraint;
+    }
 
-	public CharSequenceConstraint<T, E> url() {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			if (size().applyAsInt(x) == 0) {
-				return true;
-			}
-			try {
-				new URL(x.toString());
-				return true;
-			}
-			catch (MalformedURLException e) {
-				return false;
-			}
-		}, CHAR_SEQUENCE_URL, () -> new Object[] {}, VALID));
-		return this;
-	}
+    public CharSequenceConstraint<T, E> notBlank() {
+        this.predicates().add(ConstraintPredicate.of(x -> x != null && trim(x.toString()).length() != 0,
+                IncludedViolationMessages.get().CHAR_SEQUENCE_NOT_BLANK(), () -> new Object[]{}, INVALID));
+        return this;
+    }
 
-	public CharSequenceConstraint<T, E> variant(
-			Function<VariantOptions.Builder, VariantOptions.Builder> opts) {
-		VariantOptions.Builder builder = VariantOptions.builder();
-		CharSequenceConstraint<T, E> constraint = new CharSequenceConstraint<>(
-				this.normalizerForm, opts.apply(builder).build());
-		constraint.predicates().addAll(this.predicates());
-		return constraint;
-	}
+    private static String trim(String s) {
+        if (s.length() == 0) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder(s);
+        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
+            sb.deleteCharAt(0);
+        }
+        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
 
-	protected String normalize(String s) {
-		String str = this.variantOptions.ignored(s);
-		return this.normalizerForm == null ? str
-				: Normalizer.normalize(str, this.normalizerForm);
-	}
+    public CharSequenceConstraint<T, E> pattern(String regex) {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> Pattern.matches(regex, x), IncludedViolationMessages.get().CHAR_SEQUENCE_PATTERN(),
+                        () -> new Object[]{regex}, VALID));
+        return this;
+    }
 
-	@Override
-	protected ToIntFunction<E> size() {
-		return cs -> {
-			String s = this.normalize(cs.toString());
-			return s.codePointCount(0, s.length());
-		};
-	}
+    public CharSequenceConstraint<T, E> url() {
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            if (size().applyAsInt(x) == 0) {
+                return true;
+            }
+            try {
+                new URL(x.toString());
+                return true;
+            } catch (MalformedURLException e) {
+                return false;
+            }
+        }, IncludedViolationMessages.get().CHAR_SEQUENCE_URL(), () -> new Object[]{}, VALID));
+        return this;
+    }
 
-	private static String trim(String s) {
-		if (s.length() == 0) {
-			return s;
-		}
-		StringBuilder sb = new StringBuilder(s);
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
-			sb.deleteCharAt(0);
-		}
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
-			sb.deleteCharAt(sb.length() - 1);
-		}
-		return sb.toString();
-	}
+    public CharSequenceConstraint<T, E> variant(Function<VariantOptions.Builder, VariantOptions.Builder> opts) {
+        VariantOptions.Builder builder = VariantOptions.builder();
+        CharSequenceConstraint<T, E> constraint =
+                new CharSequenceConstraint<>(this.normalizerForm, opts.apply(builder).build());
+        constraint.predicates().addAll(this.predicates());
+        return constraint;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/CollectionConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CollectionConstraint.java
@@ -15,31 +15,32 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Collection;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.COLLECTION_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class CollectionConstraint<T, L extends Collection<E>, E>
-		extends ContainerConstraintBase<T, L, CollectionConstraint<T, L, E>> {
+        extends ContainerConstraintBase<T, L, CollectionConstraint<T, L, E>> {
 
-	@Override
-	public CollectionConstraint<T, L, E> cast() {
-		return this;
-	}
+    @Override
+    public CollectionConstraint<T, L, E> cast() {
+        return this;
+    }
 
-	public CollectionConstraint<T, L, E> contains(E s) {
-		this.predicates().add(ConstraintPredicate.of(x -> x.contains(s),
-				COLLECTION_CONTAINS, () -> new Object[] { s }, VALID));
-		return this;
-	}
+    public CollectionConstraint<T, L, E> contains(E s) {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> x.contains(s), IncludedViolationMessages.get().COLLECTION_CONTAINS(), () -> new Object[]{s},
+                        VALID));
+        return this;
+    }
 
-	@Override
-	protected ToIntFunction<L> size() {
-		return Collection::size;
-	}
+    @Override
+    protected ToIntFunction<L> size() {
+        return Collection::size;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/CollectionConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CollectionConstraint.java
@@ -25,22 +25,23 @@ import java.util.function.ToIntFunction;
 import static am.ik.yavi.core.NullAs.VALID;
 
 public class CollectionConstraint<T, L extends Collection<E>, E>
-        extends ContainerConstraintBase<T, L, CollectionConstraint<T, L, E>> {
+		extends ContainerConstraintBase<T, L, CollectionConstraint<T, L, E>> {
 
-    @Override
-    public CollectionConstraint<T, L, E> cast() {
-        return this;
-    }
+	@Override
+	public CollectionConstraint<T, L, E> cast() {
+		return this;
+	}
 
-    public CollectionConstraint<T, L, E> contains(E s) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> x.contains(s), IncludedViolationMessages.get().COLLECTION_CONTAINS(), () -> new Object[]{s},
-                        VALID));
-        return this;
-    }
+	public CollectionConstraint<T, L, E> contains(E s) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.contains(s),
+						IncludedViolationMessages.get().COLLECTION_CONTAINS(),
+						() -> new Object[] { s }, VALID));
+		return this;
+	}
 
-    @Override
-    protected ToIntFunction<L> size() {
-        return Collection::size;
-    }
+	@Override
+	protected ToIntFunction<L> size() {
+		return Collection::size;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/MapConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/MapConstraint.java
@@ -15,38 +15,38 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Map;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.MAP_CONTAINS_KEY;
-import static am.ik.yavi.core.ViolationMessage.Default.MAP_CONTAINS_VALUE;
 
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
+public class MapConstraint<T, K, V> extends ContainerConstraintBase<T, Map<K, V>, MapConstraint<T, K, V>> {
 
-public class MapConstraint<T, K, V>
-		extends ContainerConstraintBase<T, Map<K, V>, MapConstraint<T, K, V>> {
+    @Override
+    public MapConstraint<T, K, V> cast() {
+        return this;
+    }
 
-	@Override
-	public MapConstraint<T, K, V> cast() {
-		return this;
-	}
+    public MapConstraint<T, K, V> containsKey(K k) {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> x.containsKey(k), IncludedViolationMessages.get().MAP_CONTAINS_KEY(), () -> new Object[]{k},
+                        VALID));
+        return this;
+    }
 
-	public MapConstraint<T, K, V> containsKey(K k) {
-		this.predicates().add(ConstraintPredicate.of(x -> x.containsKey(k),
-				MAP_CONTAINS_KEY, () -> new Object[] { k }, VALID));
-		return this;
-	}
+    public MapConstraint<T, K, V> containsValue(V v) {
+        this.predicates().add(ConstraintPredicate
+                .of(x -> x.containsValue(v), IncludedViolationMessages.get().MAP_CONTAINS_VALUE(),
+                        () -> new Object[]{v}, VALID));
+        return this;
+    }
 
-	public MapConstraint<T, K, V> containsValue(V v) {
-		this.predicates().add(ConstraintPredicate.of(x -> x.containsValue(v),
-				MAP_CONTAINS_VALUE, () -> new Object[] { v }, VALID));
-		return this;
-	}
-
-	@Override
-	protected ToIntFunction<Map<K, V>> size() {
-		return Map::size;
-	}
+    @Override
+    protected ToIntFunction<Map<K, V>> size() {
+        return Map::size;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/MapConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/MapConstraint.java
@@ -24,29 +24,32 @@ import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class MapConstraint<T, K, V> extends ContainerConstraintBase<T, Map<K, V>, MapConstraint<T, K, V>> {
+public class MapConstraint<T, K, V>
+		extends ContainerConstraintBase<T, Map<K, V>, MapConstraint<T, K, V>> {
 
-    @Override
-    public MapConstraint<T, K, V> cast() {
-        return this;
-    }
+	@Override
+	public MapConstraint<T, K, V> cast() {
+		return this;
+	}
 
-    public MapConstraint<T, K, V> containsKey(K k) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> x.containsKey(k), IncludedViolationMessages.get().MAP_CONTAINS_KEY(), () -> new Object[]{k},
-                        VALID));
-        return this;
-    }
+	public MapConstraint<T, K, V> containsKey(K k) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.containsKey(k),
+						IncludedViolationMessages.get().MAP_CONTAINS_KEY(),
+						() -> new Object[] { k }, VALID));
+		return this;
+	}
 
-    public MapConstraint<T, K, V> containsValue(V v) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> x.containsValue(v), IncludedViolationMessages.get().MAP_CONTAINS_VALUE(),
-                        () -> new Object[]{v}, VALID));
-        return this;
-    }
+	public MapConstraint<T, K, V> containsValue(V v) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.containsValue(v),
+						IncludedViolationMessages.get().MAP_CONTAINS_VALUE(),
+						() -> new Object[] { v }, VALID));
+		return this;
+	}
 
-    @Override
-    protected ToIntFunction<Map<K, V>> size() {
-        return Map::size;
-    }
+	@Override
+	protected ToIntFunction<Map<K, V>> size() {
+		return Map::size;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/array/BooleanArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/BooleanArrayConstraint.java
@@ -39,7 +39,8 @@ public class BooleanArrayConstraint<T>
 				}
 			}
 			return false;
-		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[] { v },
+				VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/BooleanArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/BooleanArrayConstraint.java
@@ -15,13 +15,13 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class BooleanArrayConstraint<T>
 		extends ContainerConstraintBase<T, boolean[], BooleanArrayConstraint<T>> {
@@ -39,7 +39,7 @@ public class BooleanArrayConstraint<T>
 				}
 			}
 			return false;
-		}, ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/ByteArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ByteArrayConstraint.java
@@ -32,14 +32,15 @@ public class ByteArrayConstraint<T>
 	}
 
 	public ByteArrayConstraint<T> contains(byte v) {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            for (byte e : x) {
-                if (e == v) {
-                    return true;
-                }
-            }
-            return false;
-        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			for (byte e : x) {
+				if (e == v) {
+					return true;
+				}
+			}
+			return false;
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[] { v },
+				VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/ByteArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ByteArrayConstraint.java
@@ -15,13 +15,13 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class ByteArrayConstraint<T>
 		extends ContainerConstraintBase<T, byte[], ByteArrayConstraint<T>> {
@@ -32,14 +32,14 @@ public class ByteArrayConstraint<T>
 	}
 
 	public ByteArrayConstraint<T> contains(byte v) {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			for (byte e : x) {
-				if (e == v) {
-					return true;
-				}
-			}
-			return false;
-		}, ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            for (byte e : x) {
+                if (e == v) {
+                    return true;
+                }
+            }
+            return false;
+        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/CharArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/CharArrayConstraint.java
@@ -15,13 +15,13 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class CharArrayConstraint<T>
 		extends ContainerConstraintBase<T, char[], CharArrayConstraint<T>> {
@@ -32,14 +32,14 @@ public class CharArrayConstraint<T>
 	}
 
 	public CharArrayConstraint<T> contains(char v) {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			for (char e : x) {
-				if (e == v) {
-					return true;
-				}
-			}
-			return false;
-		}, ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            for (char e : x) {
+                if (e == v) {
+                    return true;
+                }
+            }
+            return false;
+        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/CharArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/CharArrayConstraint.java
@@ -32,14 +32,15 @@ public class CharArrayConstraint<T>
 	}
 
 	public CharArrayConstraint<T> contains(char v) {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            for (char e : x) {
-                if (e == v) {
-                    return true;
-                }
-            }
-            return false;
-        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			for (char e : x) {
+				if (e == v) {
+					return true;
+				}
+			}
+			return false;
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[] { v },
+				VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/DoubleArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/DoubleArrayConstraint.java
@@ -33,11 +33,12 @@ public class DoubleArrayConstraint<T>
 	}
 
 	public DoubleArrayConstraint<T> contains(double v) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
-                        () -> new Object[]{v}, VALID));
-        return this;
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
+						IncludedViolationMessages.get().ARRAY_CONTAINS(),
+						() -> new Object[] { v }, VALID));
+		return this;
+	}
 
 	@Override
 	protected ToIntFunction<double[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/DoubleArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/DoubleArrayConstraint.java
@@ -15,14 +15,14 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Arrays;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class DoubleArrayConstraint<T>
 		extends ContainerConstraintBase<T, double[], DoubleArrayConstraint<T>> {
@@ -33,11 +33,11 @@ public class DoubleArrayConstraint<T>
 	}
 
 	public DoubleArrayConstraint<T> contains(double v) {
-		this.predicates()
-				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
-						ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
-		return this;
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
+                        () -> new Object[]{v}, VALID));
+        return this;
+    }
 
 	@Override
 	protected ToIntFunction<double[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/FloatArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/FloatArrayConstraint.java
@@ -32,14 +32,15 @@ public class FloatArrayConstraint<T>
 	}
 
 	public FloatArrayConstraint<T> contains(float v) {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            for (float e : x) {
-                if (e == v) {
-                    return true;
-                }
-            }
-            return false;
-        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			for (float e : x) {
+				if (e == v) {
+					return true;
+				}
+			}
+			return false;
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[] { v },
+				VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/FloatArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/FloatArrayConstraint.java
@@ -15,13 +15,13 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class FloatArrayConstraint<T>
 		extends ContainerConstraintBase<T, float[], FloatArrayConstraint<T>> {
@@ -32,14 +32,14 @@ public class FloatArrayConstraint<T>
 	}
 
 	public FloatArrayConstraint<T> contains(float v) {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			for (float e : x) {
-				if (e == v) {
-					return true;
-				}
-			}
-			return false;
-		}, ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            for (float e : x) {
+                if (e == v) {
+                    return true;
+                }
+            }
+            return false;
+        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/array/IntArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/IntArrayConstraint.java
@@ -15,14 +15,14 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Arrays;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class IntArrayConstraint<T>
 		extends ContainerConstraintBase<T, int[], IntArrayConstraint<T>> {
@@ -33,11 +33,11 @@ public class IntArrayConstraint<T>
 	}
 
 	public IntArrayConstraint<T> contains(int v) {
-		this.predicates()
-				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
-						ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
-		return this;
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
+                        () -> new Object[]{v}, VALID));
+        return this;
+    }
 
 	@Override
 	protected ToIntFunction<int[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/IntArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/IntArrayConstraint.java
@@ -33,11 +33,12 @@ public class IntArrayConstraint<T>
 	}
 
 	public IntArrayConstraint<T> contains(int v) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
-                        () -> new Object[]{v}, VALID));
-        return this;
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
+						IncludedViolationMessages.get().ARRAY_CONTAINS(),
+						() -> new Object[] { v }, VALID));
+		return this;
+	}
 
 	@Override
 	protected ToIntFunction<int[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/LongArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/LongArrayConstraint.java
@@ -33,11 +33,12 @@ public class LongArrayConstraint<T>
 	}
 
 	public LongArrayConstraint<T> contains(long v) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
-                        () -> new Object[]{v}, VALID));
-        return this;
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
+						IncludedViolationMessages.get().ARRAY_CONTAINS(),
+						() -> new Object[] { v }, VALID));
+		return this;
+	}
 
 	@Override
 	protected ToIntFunction<long[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/LongArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/LongArrayConstraint.java
@@ -15,14 +15,14 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Arrays;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class LongArrayConstraint<T>
 		extends ContainerConstraintBase<T, long[], LongArrayConstraint<T>> {
@@ -33,11 +33,11 @@ public class LongArrayConstraint<T>
 	}
 
 	public LongArrayConstraint<T> contains(long v) {
-		this.predicates()
-				.add(ConstraintPredicate.of(x -> Arrays.stream(x).anyMatch(e -> e == v),
-						ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
-		return this;
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(x -> Arrays.stream(x).anyMatch(e -> e == v), IncludedViolationMessages.get().ARRAY_CONTAINS(),
+                        () -> new Object[]{v}, VALID));
+        return this;
+    }
 
 	@Override
 	protected ToIntFunction<long[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/ObjectArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ObjectArrayConstraint.java
@@ -15,14 +15,14 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.Arrays;
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
-
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public class ObjectArrayConstraint<T, E>
 		extends ContainerConstraintBase<T, E[], ObjectArrayConstraint<T, E>> {
@@ -33,10 +33,11 @@ public class ObjectArrayConstraint<T, E>
 	}
 
 	public ObjectArrayConstraint<T, E> contains(E s) {
-		this.predicates().add(ConstraintPredicate.of(x -> Arrays.asList(x).contains(s),
-				ARRAY_CONTAINS, () -> new Object[] { s }, VALID));
-		return this;
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(x -> Arrays.asList(x).contains(s), IncludedViolationMessages.get().ARRAY_CONTAINS(),
+                        () -> new Object[]{s}, VALID));
+        return this;
+    }
 
 	@Override
 	protected ToIntFunction<E[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/ObjectArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ObjectArrayConstraint.java
@@ -33,11 +33,12 @@ public class ObjectArrayConstraint<T, E>
 	}
 
 	public ObjectArrayConstraint<T, E> contains(E s) {
-        this.predicates().add(ConstraintPredicate
-                .of(x -> Arrays.asList(x).contains(s), IncludedViolationMessages.get().ARRAY_CONTAINS(),
-                        () -> new Object[]{s}, VALID));
-        return this;
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> Arrays.asList(x).contains(s),
+						IncludedViolationMessages.get().ARRAY_CONTAINS(),
+						() -> new Object[] { s }, VALID));
+		return this;
+	}
 
 	@Override
 	protected ToIntFunction<E[]> size() {

--- a/src/main/java/am/ik/yavi/constraint/array/ShortArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ShortArrayConstraint.java
@@ -15,36 +15,35 @@
  */
 package am.ik.yavi.constraint.array;
 
+import am.ik.yavi.constraint.base.ContainerConstraintBase;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.ARRAY_CONTAINS;
 
-import am.ik.yavi.constraint.base.ContainerConstraintBase;
-import am.ik.yavi.core.ConstraintPredicate;
+public class ShortArrayConstraint<T> extends ContainerConstraintBase<T, short[], ShortArrayConstraint<T>> {
 
-public class ShortArrayConstraint<T>
-		extends ContainerConstraintBase<T, short[], ShortArrayConstraint<T>> {
+    @Override
+    public ShortArrayConstraint<T> cast() {
+        return this;
+    }
 
-	@Override
-	public ShortArrayConstraint<T> cast() {
-		return this;
-	}
+    public ShortArrayConstraint<T> contains(short v) {
+        this.predicates().add(ConstraintPredicate.of(x -> {
+            for (short e : x) {
+                if (e == v) {
+                    return true;
+                }
+            }
+            return false;
+        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
+        return this;
+    }
 
-	public ShortArrayConstraint<T> contains(short v) {
-		this.predicates().add(ConstraintPredicate.of(x -> {
-			for (short e : x) {
-				if (e == v) {
-					return true;
-				}
-			}
-			return false;
-		}, ARRAY_CONTAINS, () -> new Object[] { v }, VALID));
-		return this;
-	}
-
-	@Override
-	protected ToIntFunction<short[]> size() {
-		return x -> x.length;
-	}
+    @Override
+    protected ToIntFunction<short[]> size() {
+        return x -> x.length;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/array/ShortArrayConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/array/ShortArrayConstraint.java
@@ -23,27 +23,29 @@ import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class ShortArrayConstraint<T> extends ContainerConstraintBase<T, short[], ShortArrayConstraint<T>> {
+public class ShortArrayConstraint<T>
+		extends ContainerConstraintBase<T, short[], ShortArrayConstraint<T>> {
 
-    @Override
-    public ShortArrayConstraint<T> cast() {
-        return this;
-    }
+	@Override
+	public ShortArrayConstraint<T> cast() {
+		return this;
+	}
 
-    public ShortArrayConstraint<T> contains(short v) {
-        this.predicates().add(ConstraintPredicate.of(x -> {
-            for (short e : x) {
-                if (e == v) {
-                    return true;
-                }
-            }
-            return false;
-        }, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[]{v}, VALID));
-        return this;
-    }
+	public ShortArrayConstraint<T> contains(short v) {
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			for (short e : x) {
+				if (e == v) {
+					return true;
+				}
+			}
+			return false;
+		}, IncludedViolationMessages.get().ARRAY_CONTAINS(), () -> new Object[] { v },
+				VALID));
+		return this;
+	}
 
-    @Override
-    protected ToIntFunction<short[]> size() {
-        return x -> x.length;
-    }
+	@Override
+	protected ToIntFunction<short[]> size() {
+		return x -> x.length;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/base/ContainerConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/ContainerConstraintBase.java
@@ -32,47 +32,60 @@ public abstract class ContainerConstraintBase<T, V, C extends Constraint<T, V, C
 		extends ConstraintBase<T, V, C> {
 
 	public C fixedSize(int size) {
-		this.predicates().add(ConstraintPredicate
-				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) == size, this.size()),
-						IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(), () -> new Object[]{size}, VALID));
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size().applyAsInt(x) == size,
+								this.size()),
+						IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(),
+						() -> new Object[] { size }, VALID));
 		return cast();
 	}
 
 	public C greaterThan(int min) {
-		this.predicates().add(ConstraintPredicate
-				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) > min, this.size()),
-						IncludedViolationMessages.get().CONTAINER_GREATER_THAN(), () -> new Object[]{min}, VALID));
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size().applyAsInt(x) > min,
+								this.size()),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN(),
+						() -> new Object[] { min }, VALID));
 		return cast();
 	}
 
 	public C greaterThanOrEqual(int min) {
 		this.predicates()
 				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) >= min, this.size()),
-						IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
-						VALID));
+						this.checkSizePredicate(x -> size().applyAsInt(x) >= min,
+								this.size()),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(),
+						() -> new Object[] { min }, VALID));
 		return cast();
 	}
 
 	public C lessThan(int max) {
-		this.predicates().add(ConstraintPredicate
-				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) < max, this.size()),
-						IncludedViolationMessages.get().CONTAINER_LESS_THAN(), () -> new Object[]{max}, VALID));
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size().applyAsInt(x) < max,
+								this.size()),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN(),
+						() -> new Object[] { max }, VALID));
 		return cast();
 	}
 
 	public C lessThanOrEqual(int max) {
-		this.predicates().add(ConstraintPredicate
-				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) <= max, this.size()),
-						IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
-						VALID));
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size().applyAsInt(x) <= max,
+								this.size()),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(),
+						() -> new Object[] { max }, VALID));
 		return cast();
 	}
 
 	public C notEmpty() {
-		this.predicates().add(ConstraintPredicate
-				.of(x -> x != null && size().applyAsInt(x) != 0, IncludedViolationMessages.get().CONTAINER_NOT_EMPTY(),
-						() -> new Object[]{}, INVALID));
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x != null && size().applyAsInt(x) != 0,
+						IncludedViolationMessages.get().CONTAINER_NOT_EMPTY(),
+						() -> new Object[] {}, INVALID));
 		return cast();
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/base/ContainerConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/ContainerConstraintBase.java
@@ -15,6 +15,11 @@
  */
 package am.ik.yavi.constraint.base;
 
+import am.ik.yavi.core.Constraint;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+import am.ik.yavi.core.ViolatedValue;
+
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -22,70 +27,52 @@ import java.util.function.ToIntFunction;
 
 import static am.ik.yavi.core.NullAs.INVALID;
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_FIXED_SIZE;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_GREATER_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_GREATER_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_LESS_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_LESS_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_NOT_EMPTY;
-
-import am.ik.yavi.core.Constraint;
-import am.ik.yavi.core.ConstraintPredicate;
-import am.ik.yavi.core.ViolatedValue;
 
 public abstract class ContainerConstraintBase<T, V, C extends Constraint<T, V, C>>
 		extends ConstraintBase<T, V, C> {
 
 	public C fixedSize(int size) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) == size,
-								this.size()),
-						CONTAINER_FIXED_SIZE, () -> new Object[] { size }, VALID));
+		this.predicates().add(ConstraintPredicate
+				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) == size, this.size()),
+						IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(), () -> new Object[]{size}, VALID));
 		return cast();
 	}
 
 	public C greaterThan(int min) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) > min,
-								this.size()),
-						CONTAINER_GREATER_THAN, () -> new Object[] { min }, VALID));
+		this.predicates().add(ConstraintPredicate
+				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) > min, this.size()),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN(), () -> new Object[]{min}, VALID));
 		return cast();
 	}
 
 	public C greaterThanOrEqual(int min) {
 		this.predicates()
 				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) >= min,
-								this.size()),
-						CONTAINER_GREATER_THAN_OR_EQUAL, () -> new Object[] { min },
+						this.checkSizePredicate(x -> size().applyAsInt(x) >= min, this.size()),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
 						VALID));
 		return cast();
 	}
 
 	public C lessThan(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) < max,
-								this.size()),
-						CONTAINER_LESS_THAN, () -> new Object[] { max }, VALID));
+		this.predicates().add(ConstraintPredicate
+				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) < max, this.size()),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN(), () -> new Object[]{max}, VALID));
 		return cast();
 	}
 
 	public C lessThanOrEqual(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size().applyAsInt(x) <= max,
-								this.size()),
-						CONTAINER_LESS_THAN_OR_EQUAL, () -> new Object[] { max }, VALID));
+		this.predicates().add(ConstraintPredicate
+				.withViolatedValue(this.checkSizePredicate(x -> size().applyAsInt(x) <= max, this.size()),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
+						VALID));
 		return cast();
 	}
 
 	public C notEmpty() {
-		this.predicates()
-				.add(ConstraintPredicate.of(x -> x != null && size().applyAsInt(x) != 0,
-						CONTAINER_NOT_EMPTY, () -> new Object[] {}, INVALID));
+		this.predicates().add(ConstraintPredicate
+				.of(x -> x != null && size().applyAsInt(x) != 0, IncludedViolationMessages.get().CONTAINER_NOT_EMPTY(),
+						() -> new Object[]{}, INVALID));
 		return cast();
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -27,32 +27,36 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 		extends ConstraintBase<T, V, C> {
 
 	public C greaterThan(V min) {
-        this.predicates().add(ConstraintPredicate
-                .of(this.isGreaterThan(min), IncludedViolationMessages.get().NUMERIC_GREATER_THAN(),
-                        () -> new Object[]{min}, VALID));
-        return cast();
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(this.isGreaterThan(min),
+						IncludedViolationMessages.get().NUMERIC_GREATER_THAN(),
+						() -> new Object[] { min }, VALID));
+		return cast();
+	}
 
 	public C greaterThanOrEqual(V min) {
-        this.predicates().add(ConstraintPredicate
-                .of(this.isGreaterThanOrEqual(min), IncludedViolationMessages.get().NUMERIC_GREATER_THAN_OR_EQUAL(),
-                        () -> new Object[]{min}, VALID));
-        return cast();
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(this.isGreaterThanOrEqual(min),
+						IncludedViolationMessages.get().NUMERIC_GREATER_THAN_OR_EQUAL(),
+						() -> new Object[] { min }, VALID));
+		return cast();
+	}
 
 	public C lessThan(V max) {
-        this.predicates().add(ConstraintPredicate
-                .of(this.isLessThan(max), IncludedViolationMessages.get().NUMERIC_LESS_THAN(), () -> new Object[]{max},
-                        VALID));
-        return cast();
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(this.isLessThan(max),
+						IncludedViolationMessages.get().NUMERIC_LESS_THAN(),
+						() -> new Object[] { max }, VALID));
+		return cast();
+	}
 
 	public C lessThanOrEqual(V max) {
-        this.predicates().add(ConstraintPredicate
-                .of(this.isLessThanOrEqual(max), IncludedViolationMessages.get().NUMERIC_LESS_THAN_OR_EQUAL(),
-                        () -> new Object[]{max}, VALID));
-        return cast();
-    }
+		this.predicates()
+				.add(ConstraintPredicate.of(this.isLessThanOrEqual(max),
+						IncludedViolationMessages.get().NUMERIC_LESS_THAN_OR_EQUAL(),
+						() -> new Object[] { max }, VALID));
+		return cast();
+	}
 
 	protected abstract Predicate<V> isGreaterThan(V min);
 

--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -15,43 +15,44 @@
  */
 package am.ik.yavi.constraint.base;
 
+import am.ik.yavi.core.Constraint;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.util.function.Predicate;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_GREATER_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_GREATER_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_LESS_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_LESS_THAN_OR_EQUAL;
-
-import am.ik.yavi.core.Constraint;
-import am.ik.yavi.core.ConstraintPredicate;
 
 public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 		extends ConstraintBase<T, V, C> {
 
 	public C greaterThan(V min) {
-		this.predicates().add(ConstraintPredicate.of(this.isGreaterThan(min),
-				NUMERIC_GREATER_THAN, () -> new Object[] { min }, VALID));
-		return cast();
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(this.isGreaterThan(min), IncludedViolationMessages.get().NUMERIC_GREATER_THAN(),
+                        () -> new Object[]{min}, VALID));
+        return cast();
+    }
 
 	public C greaterThanOrEqual(V min) {
-		this.predicates().add(ConstraintPredicate.of(this.isGreaterThanOrEqual(min),
-				NUMERIC_GREATER_THAN_OR_EQUAL, () -> new Object[] { min }, VALID));
-		return cast();
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(this.isGreaterThanOrEqual(min), IncludedViolationMessages.get().NUMERIC_GREATER_THAN_OR_EQUAL(),
+                        () -> new Object[]{min}, VALID));
+        return cast();
+    }
 
 	public C lessThan(V max) {
-		this.predicates().add(ConstraintPredicate.of(this.isLessThan(max),
-				NUMERIC_LESS_THAN, () -> new Object[] { max }, VALID));
-		return cast();
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(this.isLessThan(max), IncludedViolationMessages.get().NUMERIC_LESS_THAN(), () -> new Object[]{max},
+                        VALID));
+        return cast();
+    }
 
 	public C lessThanOrEqual(V max) {
-		this.predicates().add(ConstraintPredicate.of(this.isLessThanOrEqual(max),
-				NUMERIC_LESS_THAN_OR_EQUAL, () -> new Object[] { max }, VALID));
-		return cast();
-	}
+        this.predicates().add(ConstraintPredicate
+                .of(this.isLessThanOrEqual(max), IncludedViolationMessages.get().NUMERIC_LESS_THAN_OR_EQUAL(),
+                        () -> new Object[]{max}, VALID));
+        return cast();
+    }
 
 	protected abstract Predicate<V> isGreaterThan(V min);
 

--- a/src/main/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraint.java
@@ -15,73 +15,67 @@
  */
 package am.ik.yavi.constraint.charsequence;
 
+import am.ik.yavi.constraint.CharSequenceConstraint;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+
 import java.nio.charset.Charset;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.BYTE_SIZE_FIXED_SIZE;
-import static am.ik.yavi.core.ViolationMessage.Default.BYTE_SIZE_GREATER_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.BYTE_SIZE_GREATER_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.BYTE_SIZE_LESS_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.BYTE_SIZE_LESS_THAN_OR_EQUAL;
 
-import am.ik.yavi.constraint.CharSequenceConstraint;
-import am.ik.yavi.core.ConstraintPredicate;
+public class ByteSizeConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
 
-public class ByteSizeConstraint<T, E extends CharSequence>
-		extends CharSequenceConstraint<T, E> {
-	private final Charset charset;
+    private final Charset charset;
 
-	public ByteSizeConstraint(CharSequenceConstraint<T, E> delegate, Charset charset) {
-		super();
-		this.charset = charset;
-		this.predicates().addAll(delegate.predicates());
-	}
+    public ByteSizeConstraint(CharSequenceConstraint<T, E> delegate, Charset charset) {
+        super();
+        this.charset = charset;
+        this.predicates().addAll(delegate.predicates());
+    }
 
-	@Override
-	public ByteSizeConstraint<T, E> cast() {
-		return this;
-	}
+    @Override
+    public ByteSizeConstraint<T, E> cast() {
+        return this;
+    }
 
-	public ByteSizeConstraint<T, E> fixedSize(int size) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) == size, this::size),
-						BYTE_SIZE_FIXED_SIZE, () -> new Object[] { size }, VALID));
-		return this;
-	}
+    public ByteSizeConstraint<T, E> fixedSize(int size) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) == size, this::size),
+                        IncludedViolationMessages.get().BYTE_SIZE_FIXED_SIZE(), () -> new Object[]{size}, VALID));
+        return this;
+    }
 
-	public ByteSizeConstraint<T, E> greaterThan(int min) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) > min, this::size),
-						BYTE_SIZE_GREATER_THAN, () -> new Object[] { min }, VALID));
-		return this;
-	}
+    private int size(E x) {
+        return x.toString().getBytes(charset).length;
+    }
 
-	public ByteSizeConstraint<T, E> greaterThanOrEqual(int min) {
-		this.predicates().add(ConstraintPredicate.withViolatedValue(
-				this.checkSizePredicate(x -> size(x) >= min, this::size),
-				BYTE_SIZE_GREATER_THAN_OR_EQUAL, () -> new Object[] { min }, VALID));
-		return this;
-	}
+    public ByteSizeConstraint<T, E> greaterThan(int min) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) > min, this::size),
+                        IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN(), () -> new Object[]{min}, VALID));
+        return this;
+    }
 
-	public ByteSizeConstraint<T, E> lessThan(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) < max, this::size),
-						BYTE_SIZE_LESS_THAN, () -> new Object[] { max }, VALID));
-		return this;
-	}
+    public ByteSizeConstraint<T, E> greaterThanOrEqual(int min) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) >= min, this::size),
+                        IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
+                        VALID));
+        return this;
+    }
 
-	public ByteSizeConstraint<T, E> lessThanOrEqual(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) <= max, this::size),
-						BYTE_SIZE_LESS_THAN_OR_EQUAL, () -> new Object[] { max }, VALID));
-		return this;
-	}
+    public ByteSizeConstraint<T, E> lessThan(int max) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) < max, this::size),
+                        IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN(), () -> new Object[]{max}, VALID));
+        return this;
+    }
 
-	private int size(E x) {
-		return x.toString().getBytes(charset).length;
-	}
+    public ByteSizeConstraint<T, E> lessThanOrEqual(int max) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) <= max, this::size),
+                        IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
+                        VALID));
+        return this;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraint.java
@@ -23,59 +23,68 @@ import java.nio.charset.Charset;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class ByteSizeConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
+public class ByteSizeConstraint<T, E extends CharSequence>
+		extends CharSequenceConstraint<T, E> {
 
-    private final Charset charset;
+	private final Charset charset;
 
-    public ByteSizeConstraint(CharSequenceConstraint<T, E> delegate, Charset charset) {
-        super();
-        this.charset = charset;
-        this.predicates().addAll(delegate.predicates());
-    }
+	public ByteSizeConstraint(CharSequenceConstraint<T, E> delegate, Charset charset) {
+		super();
+		this.charset = charset;
+		this.predicates().addAll(delegate.predicates());
+	}
 
-    @Override
-    public ByteSizeConstraint<T, E> cast() {
-        return this;
-    }
+	@Override
+	public ByteSizeConstraint<T, E> cast() {
+		return this;
+	}
 
-    public ByteSizeConstraint<T, E> fixedSize(int size) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) == size, this::size),
-                        IncludedViolationMessages.get().BYTE_SIZE_FIXED_SIZE(), () -> new Object[]{size}, VALID));
-        return this;
-    }
+	public ByteSizeConstraint<T, E> fixedSize(int size) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) == size, this::size),
+						IncludedViolationMessages.get().BYTE_SIZE_FIXED_SIZE(),
+						() -> new Object[] { size }, VALID));
+		return this;
+	}
 
-    private int size(E x) {
-        return x.toString().getBytes(charset).length;
-    }
+	private int size(E x) {
+		return x.toString().getBytes(charset).length;
+	}
 
-    public ByteSizeConstraint<T, E> greaterThan(int min) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) > min, this::size),
-                        IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN(), () -> new Object[]{min}, VALID));
-        return this;
-    }
+	public ByteSizeConstraint<T, E> greaterThan(int min) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) > min, this::size),
+						IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN(),
+						() -> new Object[] { min }, VALID));
+		return this;
+	}
 
-    public ByteSizeConstraint<T, E> greaterThanOrEqual(int min) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) >= min, this::size),
-                        IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
-                        VALID));
-        return this;
-    }
+	public ByteSizeConstraint<T, E> greaterThanOrEqual(int min) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) >= min, this::size),
+						IncludedViolationMessages.get().BYTE_SIZE_GREATER_THAN_OR_EQUAL(),
+						() -> new Object[] { min }, VALID));
+		return this;
+	}
 
-    public ByteSizeConstraint<T, E> lessThan(int max) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) < max, this::size),
-                        IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN(), () -> new Object[]{max}, VALID));
-        return this;
-    }
+	public ByteSizeConstraint<T, E> lessThan(int max) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) < max, this::size),
+						IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN(),
+						() -> new Object[] { max }, VALID));
+		return this;
+	}
 
-    public ByteSizeConstraint<T, E> lessThanOrEqual(int max) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) <= max, this::size),
-                        IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
-                        VALID));
-        return this;
-    }
+	public ByteSizeConstraint<T, E> lessThanOrEqual(int max) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) <= max, this::size),
+						IncludedViolationMessages.get().BYTE_SIZE_LESS_THAN_OR_EQUAL(),
+						() -> new Object[] { max }, VALID));
+		return this;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/charsequence/CodePointsConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/CodePointsConstraint.java
@@ -15,6 +15,11 @@
  */
 package am.ik.yavi.constraint.charsequence;
 
+import am.ik.yavi.constraint.CharSequenceConstraint;
+import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
+import am.ik.yavi.core.ViolatedValue;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -22,86 +27,76 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.CODE_POINTS_ALL_INCLUDED;
-import static am.ik.yavi.core.ViolationMessage.Default.CODE_POINTS_NOT_INCLUDED;
 
-import am.ik.yavi.constraint.CharSequenceConstraint;
-import am.ik.yavi.core.ConstraintPredicate;
-import am.ik.yavi.core.ViolatedValue;
+public class CodePointsConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
 
-public class CodePointsConstraint<T, E extends CharSequence>
-		extends CharSequenceConstraint<T, E> {
-	private final CodePoints<E> codePoints;
+    private final CodePoints<E> codePoints;
 
-	public CodePointsConstraint(CharSequenceConstraint<T, E> delegate,
-			CodePoints<E> codePoints) {
-		super();
-		this.codePoints = codePoints;
-		this.predicates().addAll(delegate.predicates());
-	}
+    public CodePointsConstraint(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
+        super();
+        this.codePoints = codePoints;
+        this.predicates().addAll(delegate.predicates());
+    }
 
-	public CodePointsConstraint<T, E> asBlackList() {
-		this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
-			Set<Integer> excludedFromBlackList = this.codePoints.allExcludedCodePoints(x);
-			Integer codePoint;
-			String str = x.toString();
-			int len = str.length();
-			Set<Integer> included = new LinkedHashSet<>();
-			for (int i = 0; i < len; i += Character.charCount(codePoint)) {
-				codePoint = str.codePointAt(i);
-				if (!excludedFromBlackList.contains(codePoint)) {
-					included.add(codePoint);
-				}
-			}
-			if (included.isEmpty()) {
-				return Optional.empty();
-			}
-			List<String> includedList = included.stream() //
-					.map(i -> new String(new int[] { i }, 0, 1)) //
-					.collect(Collectors.toList());
-			return Optional.of(new ViolatedValue(includedList));
-		}, CODE_POINTS_NOT_INCLUDED, () -> new Object[] {}, VALID));
-		return this;
-	}
+    public CodePointsConstraint<T, E> asBlackList() {
+        this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
+            Set<Integer> excludedFromBlackList = this.codePoints.allExcludedCodePoints(x);
+            Integer codePoint;
+            String str = x.toString();
+            int len = str.length();
+            Set<Integer> included = new LinkedHashSet<>();
+            for (int i = 0; i < len; i += Character.charCount(codePoint)) {
+                codePoint = str.codePointAt(i);
+                if (!excludedFromBlackList.contains(codePoint)) {
+                    included.add(codePoint);
+                }
+            }
+            if (included.isEmpty()) {
+                return Optional.empty();
+            }
+            List<String> includedList = included.stream() //
+                    .map(i -> new String(new int[]{i}, 0, 1)) //
+                    .collect(Collectors.toList());
+            return Optional.of(new ViolatedValue(includedList));
+        }, IncludedViolationMessages.get().CODE_POINTS_NOT_INCLUDED(), () -> new Object[]{}, VALID));
+        return this;
+    }
 
-	public CodePointsConstraint<T, E> asWhiteList() {
-		this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
-			Set<Integer> excludedFromWhiteList = this.codePoints.allExcludedCodePoints(x);
-			if (excludedFromWhiteList.isEmpty()) {
-				return Optional.empty();
-			}
-			List<String> excludedList = excludedFromWhiteList.stream() //
-					.map(i -> new String(new int[] { i }, 0, 1)) //
-					.collect(Collectors.toList());
-			return Optional.of(new ViolatedValue(excludedList));
-		}, CODE_POINTS_ALL_INCLUDED, () -> new Object[] {}, VALID));
-		return this;
-	}
+    public CodePointsConstraint<T, E> asWhiteList() {
+        this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
+            Set<Integer> excludedFromWhiteList = this.codePoints.allExcludedCodePoints(x);
+            if (excludedFromWhiteList.isEmpty()) {
+                return Optional.empty();
+            }
+            List<String> excludedList = excludedFromWhiteList.stream() //
+                    .map(i -> new String(new int[]{i}, 0, 1)) //
+                    .collect(Collectors.toList());
+            return Optional.of(new ViolatedValue(excludedList));
+        }, IncludedViolationMessages.get().CODE_POINTS_ALL_INCLUDED(), () -> new Object[]{}, VALID));
+        return this;
+    }
 
-	@Override
-	public CodePointsConstraint<T, E> cast() {
-		return this;
-	}
+    @Override
+    public CodePointsConstraint<T, E> cast() {
+        return this;
+    }
 
-	public static class Builder<T, E extends CharSequence> {
-		private final CodePoints<E> codePoints;
+    public static class Builder<T, E extends CharSequence> {
 
-		private final CharSequenceConstraint<T, E> delegate;
+        private final CodePoints<E> codePoints;
+        private final CharSequenceConstraint<T, E> delegate;
 
-		public Builder(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
-			this.delegate = delegate;
-			this.codePoints = codePoints;
-		}
+        public Builder(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
+            this.delegate = delegate;
+            this.codePoints = codePoints;
+        }
 
-		public CodePointsConstraint<T, E> asBlackList() {
-			return new CodePointsConstraint<>(this.delegate, this.codePoints)
-					.asBlackList();
-		}
+        public CodePointsConstraint<T, E> asBlackList() {
+            return new CodePointsConstraint<>(this.delegate, this.codePoints).asBlackList();
+        }
 
-		public CodePointsConstraint<T, E> asWhiteList() {
-			return new CodePointsConstraint<>(this.delegate, this.codePoints)
-					.asWhiteList();
-		}
-	}
-
+        public CodePointsConstraint<T, E> asWhiteList() {
+            return new CodePointsConstraint<>(this.delegate, this.codePoints).asWhiteList();
+        }
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/charsequence/CodePointsConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/CodePointsConstraint.java
@@ -28,75 +28,81 @@ import java.util.stream.Collectors;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class CodePointsConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
+public class CodePointsConstraint<T, E extends CharSequence>
+		extends CharSequenceConstraint<T, E> {
 
-    private final CodePoints<E> codePoints;
+	private final CodePoints<E> codePoints;
 
-    public CodePointsConstraint(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
-        super();
-        this.codePoints = codePoints;
-        this.predicates().addAll(delegate.predicates());
-    }
+	public CodePointsConstraint(CharSequenceConstraint<T, E> delegate,
+			CodePoints<E> codePoints) {
+		super();
+		this.codePoints = codePoints;
+		this.predicates().addAll(delegate.predicates());
+	}
 
-    public CodePointsConstraint<T, E> asBlackList() {
-        this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
-            Set<Integer> excludedFromBlackList = this.codePoints.allExcludedCodePoints(x);
-            Integer codePoint;
-            String str = x.toString();
-            int len = str.length();
-            Set<Integer> included = new LinkedHashSet<>();
-            for (int i = 0; i < len; i += Character.charCount(codePoint)) {
-                codePoint = str.codePointAt(i);
-                if (!excludedFromBlackList.contains(codePoint)) {
-                    included.add(codePoint);
-                }
-            }
-            if (included.isEmpty()) {
-                return Optional.empty();
-            }
-            List<String> includedList = included.stream() //
-                    .map(i -> new String(new int[]{i}, 0, 1)) //
-                    .collect(Collectors.toList());
-            return Optional.of(new ViolatedValue(includedList));
-        }, IncludedViolationMessages.get().CODE_POINTS_NOT_INCLUDED(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public CodePointsConstraint<T, E> asBlackList() {
+		this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
+			Set<Integer> excludedFromBlackList = this.codePoints.allExcludedCodePoints(x);
+			Integer codePoint;
+			String str = x.toString();
+			int len = str.length();
+			Set<Integer> included = new LinkedHashSet<>();
+			for (int i = 0; i < len; i += Character.charCount(codePoint)) {
+				codePoint = str.codePointAt(i);
+				if (!excludedFromBlackList.contains(codePoint)) {
+					included.add(codePoint);
+				}
+			}
+			if (included.isEmpty()) {
+				return Optional.empty();
+			}
+			List<String> includedList = included.stream() //
+					.map(i -> new String(new int[] { i }, 0, 1)) //
+					.collect(Collectors.toList());
+			return Optional.of(new ViolatedValue(includedList));
+		}, IncludedViolationMessages.get().CODE_POINTS_NOT_INCLUDED(),
+				() -> new Object[] {}, VALID));
+		return this;
+	}
 
-    public CodePointsConstraint<T, E> asWhiteList() {
-        this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
-            Set<Integer> excludedFromWhiteList = this.codePoints.allExcludedCodePoints(x);
-            if (excludedFromWhiteList.isEmpty()) {
-                return Optional.empty();
-            }
-            List<String> excludedList = excludedFromWhiteList.stream() //
-                    .map(i -> new String(new int[]{i}, 0, 1)) //
-                    .collect(Collectors.toList());
-            return Optional.of(new ViolatedValue(excludedList));
-        }, IncludedViolationMessages.get().CODE_POINTS_ALL_INCLUDED(), () -> new Object[]{}, VALID));
-        return this;
-    }
+	public CodePointsConstraint<T, E> asWhiteList() {
+		this.predicates().add(ConstraintPredicate.withViolatedValue(x -> {
+			Set<Integer> excludedFromWhiteList = this.codePoints.allExcludedCodePoints(x);
+			if (excludedFromWhiteList.isEmpty()) {
+				return Optional.empty();
+			}
+			List<String> excludedList = excludedFromWhiteList.stream() //
+					.map(i -> new String(new int[] { i }, 0, 1)) //
+					.collect(Collectors.toList());
+			return Optional.of(new ViolatedValue(excludedList));
+		}, IncludedViolationMessages.get().CODE_POINTS_ALL_INCLUDED(),
+				() -> new Object[] {}, VALID));
+		return this;
+	}
 
-    @Override
-    public CodePointsConstraint<T, E> cast() {
-        return this;
-    }
+	@Override
+	public CodePointsConstraint<T, E> cast() {
+		return this;
+	}
 
-    public static class Builder<T, E extends CharSequence> {
+	public static class Builder<T, E extends CharSequence> {
 
-        private final CodePoints<E> codePoints;
-        private final CharSequenceConstraint<T, E> delegate;
+		private final CodePoints<E> codePoints;
+		private final CharSequenceConstraint<T, E> delegate;
 
-        public Builder(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
-            this.delegate = delegate;
-            this.codePoints = codePoints;
-        }
+		public Builder(CharSequenceConstraint<T, E> delegate, CodePoints<E> codePoints) {
+			this.delegate = delegate;
+			this.codePoints = codePoints;
+		}
 
-        public CodePointsConstraint<T, E> asBlackList() {
-            return new CodePointsConstraint<>(this.delegate, this.codePoints).asBlackList();
-        }
+		public CodePointsConstraint<T, E> asBlackList() {
+			return new CodePointsConstraint<>(this.delegate, this.codePoints)
+					.asBlackList();
+		}
 
-        public CodePointsConstraint<T, E> asWhiteList() {
-            return new CodePointsConstraint<>(this.delegate, this.codePoints).asWhiteList();
-        }
-    }
+		public CodePointsConstraint<T, E> asWhiteList() {
+			return new CodePointsConstraint<>(this.delegate, this.codePoints)
+					.asWhiteList();
+		}
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/charsequence/EmojiConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/EmojiConstraint.java
@@ -15,68 +15,61 @@
  */
 package am.ik.yavi.constraint.charsequence;
 
-import java.text.Normalizer;
-
-import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_FIXED_SIZE;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_GREATER_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_GREATER_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_LESS_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.CONTAINER_LESS_THAN_OR_EQUAL;
-
 import am.ik.yavi.constraint.CharSequenceConstraint;
 import am.ik.yavi.constraint.charsequence.variant.VariantOptions;
 import am.ik.yavi.core.ConstraintPredicate;
+import am.ik.yavi.core.IncludedViolationMessages;
 
-public class EmojiConstraint<T, E extends CharSequence>
-		extends CharSequenceConstraint<T, E> {
+import java.text.Normalizer;
 
-	public EmojiConstraint(CharSequenceConstraint<T, E> delegate,
-			Normalizer.Form normalizerForm, VariantOptions variantOptions) {
-		super(normalizerForm, variantOptions);
-		this.predicates().addAll(delegate.predicates());
-	}
+import static am.ik.yavi.core.NullAs.VALID;
 
-	public EmojiConstraint<T, E> fixedSize(int size) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) == size, this::size),
-						CONTAINER_FIXED_SIZE, () -> new Object[] { size }, VALID));
-		return this;
-	}
+public class EmojiConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
 
-	public EmojiConstraint<T, E> greaterThan(int min) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) > min, this::size),
-						CONTAINER_GREATER_THAN, () -> new Object[] { min }, VALID));
-		return this;
-	}
+    public EmojiConstraint(CharSequenceConstraint<T, E> delegate, Normalizer.Form normalizerForm,
+            VariantOptions variantOptions) {
+        super(normalizerForm, variantOptions);
+        this.predicates().addAll(delegate.predicates());
+    }
 
-	public EmojiConstraint<T, E> greaterThanOrEqual(int min) {
-		this.predicates().add(ConstraintPredicate.withViolatedValue(
-				this.checkSizePredicate(x -> size(x) >= min, this::size),
-				CONTAINER_GREATER_THAN_OR_EQUAL, () -> new Object[] { min }, VALID));
-		return this;
-	}
+    public EmojiConstraint<T, E> fixedSize(int size) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) == size, this::size),
+                        IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(), () -> new Object[]{size}, VALID));
+        return this;
+    }
 
-	public EmojiConstraint<T, E> lessThan(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) < max, this::size),
-						CONTAINER_LESS_THAN, () -> new Object[] { max }, VALID));
-		return this;
-	}
+    private int size(E x) {
+        return Emoji.bestEffortCount(this.normalize(x.toString()));
+    }
 
-	public EmojiConstraint<T, E> lessThanOrEqual(int max) {
-		this.predicates()
-				.add(ConstraintPredicate.withViolatedValue(
-						this.checkSizePredicate(x -> size(x) <= max, this::size),
-						CONTAINER_LESS_THAN_OR_EQUAL, () -> new Object[] { max }, VALID));
-		return this;
-	}
+    public EmojiConstraint<T, E> greaterThan(int min) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) > min, this::size),
+                        IncludedViolationMessages.get().CONTAINER_GREATER_THAN(), () -> new Object[]{min}, VALID));
+        return this;
+    }
 
-	private int size(E x) {
-		return Emoji.bestEffortCount(this.normalize(x.toString()));
-	}
+    public EmojiConstraint<T, E> greaterThanOrEqual(int min) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) >= min, this::size),
+                        IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
+                        VALID));
+        return this;
+    }
+
+    public EmojiConstraint<T, E> lessThan(int max) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) < max, this::size),
+                        IncludedViolationMessages.get().CONTAINER_LESS_THAN(), () -> new Object[]{max}, VALID));
+        return this;
+    }
+
+    public EmojiConstraint<T, E> lessThanOrEqual(int max) {
+        this.predicates().add(ConstraintPredicate
+                .withViolatedValue(this.checkSizePredicate(x -> size(x) <= max, this::size),
+                        IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
+                        VALID));
+        return this;
+    }
 }

--- a/src/main/java/am/ik/yavi/constraint/charsequence/EmojiConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/charsequence/EmojiConstraint.java
@@ -24,52 +24,61 @@ import java.text.Normalizer;
 
 import static am.ik.yavi.core.NullAs.VALID;
 
-public class EmojiConstraint<T, E extends CharSequence> extends CharSequenceConstraint<T, E> {
+public class EmojiConstraint<T, E extends CharSequence>
+		extends CharSequenceConstraint<T, E> {
 
-    public EmojiConstraint(CharSequenceConstraint<T, E> delegate, Normalizer.Form normalizerForm,
-            VariantOptions variantOptions) {
-        super(normalizerForm, variantOptions);
-        this.predicates().addAll(delegate.predicates());
-    }
+	public EmojiConstraint(CharSequenceConstraint<T, E> delegate,
+			Normalizer.Form normalizerForm, VariantOptions variantOptions) {
+		super(normalizerForm, variantOptions);
+		this.predicates().addAll(delegate.predicates());
+	}
 
-    public EmojiConstraint<T, E> fixedSize(int size) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) == size, this::size),
-                        IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(), () -> new Object[]{size}, VALID));
-        return this;
-    }
+	public EmojiConstraint<T, E> fixedSize(int size) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) == size, this::size),
+						IncludedViolationMessages.get().CONTAINER_FIXED_SIZE(),
+						() -> new Object[] { size }, VALID));
+		return this;
+	}
 
-    private int size(E x) {
-        return Emoji.bestEffortCount(this.normalize(x.toString()));
-    }
+	private int size(E x) {
+		return Emoji.bestEffortCount(this.normalize(x.toString()));
+	}
 
-    public EmojiConstraint<T, E> greaterThan(int min) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) > min, this::size),
-                        IncludedViolationMessages.get().CONTAINER_GREATER_THAN(), () -> new Object[]{min}, VALID));
-        return this;
-    }
+	public EmojiConstraint<T, E> greaterThan(int min) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) > min, this::size),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN(),
+						() -> new Object[] { min }, VALID));
+		return this;
+	}
 
-    public EmojiConstraint<T, E> greaterThanOrEqual(int min) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) >= min, this::size),
-                        IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(), () -> new Object[]{min},
-                        VALID));
-        return this;
-    }
+	public EmojiConstraint<T, E> greaterThanOrEqual(int min) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) >= min, this::size),
+						IncludedViolationMessages.get().CONTAINER_GREATER_THAN_OR_EQUAL(),
+						() -> new Object[] { min }, VALID));
+		return this;
+	}
 
-    public EmojiConstraint<T, E> lessThan(int max) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) < max, this::size),
-                        IncludedViolationMessages.get().CONTAINER_LESS_THAN(), () -> new Object[]{max}, VALID));
-        return this;
-    }
+	public EmojiConstraint<T, E> lessThan(int max) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) < max, this::size),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN(),
+						() -> new Object[] { max }, VALID));
+		return this;
+	}
 
-    public EmojiConstraint<T, E> lessThanOrEqual(int max) {
-        this.predicates().add(ConstraintPredicate
-                .withViolatedValue(this.checkSizePredicate(x -> size(x) <= max, this::size),
-                        IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(), () -> new Object[]{max},
-                        VALID));
-        return this;
-    }
+	public EmojiConstraint<T, E> lessThanOrEqual(int max) {
+		this.predicates()
+				.add(ConstraintPredicate.withViolatedValue(
+						this.checkSizePredicate(x -> size(x) <= max, this::size),
+						IncludedViolationMessages.get().CONTAINER_LESS_THAN_OR_EQUAL(),
+						() -> new Object[] { max }, VALID));
+		return this;
+	}
 }

--- a/src/main/java/am/ik/yavi/core/Constraint.java
+++ b/src/main/java/am/ik/yavi/core/Constraint.java
@@ -21,58 +21,62 @@ import java.util.function.Predicate;
 
 public interface Constraint<T, V, C extends Constraint<T, V, C>> {
 
-    default C isNull() {
-        this.predicates().add(ConstraintPredicate
-                .of(Objects::isNull, IncludedViolationMessages.get().OBJECT_IS_NULL(), () -> new Object[]{},
-                        NullAs.INVALID));
-        return this.cast();
-    }
+	default C isNull() {
+		this.predicates()
+				.add(ConstraintPredicate.of(Objects::isNull,
+						IncludedViolationMessages.get().OBJECT_IS_NULL(),
+						() -> new Object[] {}, NullAs.INVALID));
+		return this.cast();
+	}
 
-    Deque<ConstraintPredicate<V>> predicates();
+	Deque<ConstraintPredicate<V>> predicates();
 
-    C cast();
+	C cast();
 
-    default C message(String message) {
-        ConstraintPredicate<V> predicate = this.predicates().pollLast();
-        if (predicate == null) {
-            throw new IllegalStateException("no constraint found to override!");
-        }
-        this.predicates().addLast(predicate.overrideMessage(message));
-        return this.cast();
-    }
+	default C message(String message) {
+		ConstraintPredicate<V> predicate = this.predicates().pollLast();
+		if (predicate == null) {
+			throw new IllegalStateException("no constraint found to override!");
+		}
+		this.predicates().addLast(predicate.overrideMessage(message));
+		return this.cast();
+	}
 
-    default C message(ViolationMessage message) {
-        ConstraintPredicate<V> predicate = this.predicates().pollLast();
-        if (predicate == null) {
-            throw new IllegalStateException("no constraint found to override!");
-        }
-        this.predicates().addLast(predicate.overrideMessage(message));
-        return this.cast();
-    }
+	default C message(ViolationMessage message) {
+		ConstraintPredicate<V> predicate = this.predicates().pollLast();
+		if (predicate == null) {
+			throw new IllegalStateException("no constraint found to override!");
+		}
+		this.predicates().addLast(predicate.overrideMessage(message));
+		return this.cast();
+	}
 
-    default C notNull() {
-        this.predicates().add(ConstraintPredicate
-                .of(Objects::nonNull, IncludedViolationMessages.get().OBJECT_NOT_NULL(), () -> new Object[]{},
-                        NullAs.INVALID));
-        return this.cast();
-    }
+	default C notNull() {
+		this.predicates()
+				.add(ConstraintPredicate.of(Objects::nonNull,
+						IncludedViolationMessages.get().OBJECT_NOT_NULL(),
+						() -> new Object[] {}, NullAs.INVALID));
+		return this.cast();
+	}
 
-    default C predicate(CustomConstraint<V> constraint) {
-        return this.predicate(constraint, constraint);
-    }
+	default C predicate(CustomConstraint<V> constraint) {
+		return this.predicate(constraint, constraint);
+	}
 
-    default C predicate(Predicate<V> predicate, ViolationMessage violationMessage) {
-        this.predicates().add(ConstraintPredicate.of(predicate, violationMessage, () -> new Object[]{}, NullAs.VALID));
-        return this.cast();
-    }
+	default C predicate(Predicate<V> predicate, ViolationMessage violationMessage) {
+		this.predicates().add(ConstraintPredicate.of(predicate, violationMessage,
+				() -> new Object[] {}, NullAs.VALID));
+		return this.cast();
+	}
 
-    default C predicateNullable(CustomConstraint<V> constraint) {
-        return this.predicateNullable(constraint, constraint);
-    }
+	default C predicateNullable(CustomConstraint<V> constraint) {
+		return this.predicateNullable(constraint, constraint);
+	}
 
-    default C predicateNullable(Predicate<V> predicate, ViolationMessage violationMessage) {
-        this.predicates()
-                .add(ConstraintPredicate.of(predicate, violationMessage, () -> new Object[]{}, NullAs.INVALID));
-        return this.cast();
-    }
+	default C predicateNullable(Predicate<V> predicate,
+			ViolationMessage violationMessage) {
+		this.predicates().add(ConstraintPredicate.of(predicate, violationMessage,
+				() -> new Object[] {}, NullAs.INVALID));
+		return this.cast();
+	}
 }

--- a/src/main/java/am/ik/yavi/core/Constraint.java
+++ b/src/main/java/am/ik/yavi/core/Constraint.java
@@ -19,63 +19,60 @@ import java.util.Deque;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import static am.ik.yavi.core.ViolationMessage.Default.OBJECT_IS_NULL;
-import static am.ik.yavi.core.ViolationMessage.Default.OBJECT_NOT_NULL;
-
 public interface Constraint<T, V, C extends Constraint<T, V, C>> {
 
-	C cast();
+    default C isNull() {
+        this.predicates().add(ConstraintPredicate
+                .of(Objects::isNull, IncludedViolationMessages.get().OBJECT_IS_NULL(), () -> new Object[]{},
+                        NullAs.INVALID));
+        return this.cast();
+    }
 
-	default C isNull() {
-		this.predicates().add(ConstraintPredicate.of(Objects::isNull, OBJECT_IS_NULL,
-				() -> new Object[] {}, NullAs.INVALID));
-		return this.cast();
-	}
+    Deque<ConstraintPredicate<V>> predicates();
 
-	default C message(String message) {
-		ConstraintPredicate<V> predicate = this.predicates().pollLast();
-		if (predicate == null) {
-			throw new IllegalStateException("no constraint found to override!");
-		}
-		this.predicates().addLast(predicate.overrideMessage(message));
-		return this.cast();
-	}
+    C cast();
 
-	default C message(ViolationMessage message) {
-		ConstraintPredicate<V> predicate = this.predicates().pollLast();
-		if (predicate == null) {
-			throw new IllegalStateException("no constraint found to override!");
-		}
-		this.predicates().addLast(predicate.overrideMessage(message));
-		return this.cast();
-	}
+    default C message(String message) {
+        ConstraintPredicate<V> predicate = this.predicates().pollLast();
+        if (predicate == null) {
+            throw new IllegalStateException("no constraint found to override!");
+        }
+        this.predicates().addLast(predicate.overrideMessage(message));
+        return this.cast();
+    }
 
-	default C notNull() {
-		this.predicates().add(ConstraintPredicate.of(Objects::nonNull, OBJECT_NOT_NULL,
-				() -> new Object[] {}, NullAs.INVALID));
-		return this.cast();
-	}
+    default C message(ViolationMessage message) {
+        ConstraintPredicate<V> predicate = this.predicates().pollLast();
+        if (predicate == null) {
+            throw new IllegalStateException("no constraint found to override!");
+        }
+        this.predicates().addLast(predicate.overrideMessage(message));
+        return this.cast();
+    }
 
-	default C predicate(Predicate<V> predicate, ViolationMessage violationMessage) {
-		this.predicates().add(ConstraintPredicate.of(predicate, violationMessage,
-				() -> new Object[] {}, NullAs.VALID));
-		return this.cast();
-	}
+    default C notNull() {
+        this.predicates().add(ConstraintPredicate
+                .of(Objects::nonNull, IncludedViolationMessages.get().OBJECT_NOT_NULL(), () -> new Object[]{},
+                        NullAs.INVALID));
+        return this.cast();
+    }
 
-	default C predicate(CustomConstraint<V> constraint) {
-		return this.predicate(constraint, constraint);
-	}
+    default C predicate(CustomConstraint<V> constraint) {
+        return this.predicate(constraint, constraint);
+    }
 
-	default C predicateNullable(Predicate<V> predicate,
-			ViolationMessage violationMessage) {
-		this.predicates().add(ConstraintPredicate.of(predicate, violationMessage,
-				() -> new Object[] {}, NullAs.INVALID));
-		return this.cast();
-	}
+    default C predicate(Predicate<V> predicate, ViolationMessage violationMessage) {
+        this.predicates().add(ConstraintPredicate.of(predicate, violationMessage, () -> new Object[]{}, NullAs.VALID));
+        return this.cast();
+    }
 
-	default C predicateNullable(CustomConstraint<V> constraint) {
-		return this.predicateNullable(constraint, constraint);
-	}
+    default C predicateNullable(CustomConstraint<V> constraint) {
+        return this.predicateNullable(constraint, constraint);
+    }
 
-	Deque<ConstraintPredicate<V>> predicates();
+    default C predicateNullable(Predicate<V> predicate, ViolationMessage violationMessage) {
+        this.predicates()
+                .add(ConstraintPredicate.of(predicate, violationMessage, () -> new Object[]{}, NullAs.INVALID));
+        return this.cast();
+    }
 }

--- a/src/main/java/am/ik/yavi/core/DefaultIncludedViolationMessages.java
+++ b/src/main/java/am/ik/yavi/core/DefaultIncludedViolationMessages.java
@@ -1,0 +1,162 @@
+package am.ik.yavi.core;
+
+public class DefaultIncludedViolationMessages extends IncludedViolationMessages {
+
+    @Override
+    public ViolationMessage OBJECT_NOT_NULL() {
+        return ViolationMessage.of("object.notNull", "\"{0}\" must not be null");
+    }
+
+    @Override
+    public ViolationMessage OBJECT_IS_NULL() {
+        return ViolationMessage.of("object.isNull", "\"{0}\" must be null");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_NOT_EMPTY() {
+        return ViolationMessage.of("container.notEmpty", "\"{0}\" must not be empty");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_LESS_THAN() {
+        return ViolationMessage
+                .of("container.lessThan", "The size of \"{0}\" must be less than {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
+        return ViolationMessage.of("container.lessThanOrEqual",
+                "The size of \"{0}\" must be less than or equal to {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_GREATER_THAN() {
+        return ViolationMessage
+                .of("container.greaterThan", "The size of \"{0}\" must be greater than {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
+        return ViolationMessage.of("container.greaterThanOrEqual",
+                "The size of \"{0}\" must be greater than or equal to {1}. The given size is" + " {2}");
+    }
+
+    @Override
+    public ViolationMessage CONTAINER_FIXED_SIZE() {
+        return ViolationMessage.of("container.fixedSize", "The size of \"{0}\" must be {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage NUMERIC_GREATER_THAN() {
+        return ViolationMessage.of("numeric.greaterThan", "\"{0}\" must be greater than {1}");
+    }
+
+    @Override
+    public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
+        return ViolationMessage.of("numeric.greaterThanOrEqual", "\"{0}\" must be greater than or equal to {1}");
+    }
+
+    @Override
+    public ViolationMessage NUMERIC_LESS_THAN() {
+        return ViolationMessage.of("numeric.lessThan", "\"{0}\" must be less than {1}");
+    }
+
+    @Override
+    public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
+        return ViolationMessage.of("numeric.lessThanOrEqual", "\"{0}\" must be less than or equal to {1}");
+    }
+
+    @Override
+    public ViolationMessage BOOLEAN_IS_TRUE() {
+        return ViolationMessage.of("boolean.isTrue", "\"{0}\" must be true");
+    }
+
+    @Override
+    public ViolationMessage BOOLEAN_IS_FALSE() {
+        return ViolationMessage.of("boolean.isFalse", "\"{0}\" must be false");
+    }
+
+    @Override
+    public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
+        return ViolationMessage.of("charSequence.notBlank", "\"{0}\" must not be blank");
+    }
+
+    @Override
+    public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
+        return ViolationMessage.of("charSequence.contains", "\"{0}\" must contain {1}");
+    }
+
+    @Override
+    public ViolationMessage CHAR_SEQUENCE_EMAIL() {
+        return ViolationMessage.of("charSequence.email", "\"{0}\" must be a valid email address");
+    }
+
+    @Override
+    public ViolationMessage CHAR_SEQUENCE_URL() {
+        return ViolationMessage.of("charSequence.url", "\"{0}\" must be a valid URL");
+    }
+
+    @Override
+    public ViolationMessage CHAR_SEQUENCE_PATTERN() {
+        return ViolationMessage.of("charSequence.pattern", "\"{0}\" must match {1}");
+    }
+
+    @Override
+    public ViolationMessage BYTE_SIZE_LESS_THAN() {
+        return ViolationMessage
+                .of("byteSize.lessThan", "The size of \"{0}\" must be less than {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
+        return ViolationMessage.of("byteSize.lessThanOrEqual",
+                "The byte size of \"{0}\" must be less than or equal to {1}. The given size is " + "{2}");
+    }
+
+    @Override
+    public ViolationMessage BYTE_SIZE_GREATER_THAN() {
+        return ViolationMessage
+                .of("byteSize.greaterThan", "The byte size of \"{0}\" must be greater than {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
+        return ViolationMessage.of("byteSize.greaterThanOrEqual",
+                "The byte size of \"{0}\" must be greater than or equal to {1}. The given " + "size is {2}");
+    }
+
+    @Override
+    public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
+        return ViolationMessage.of("byteSize.fixedSize", "The byte size of \"{0}\" must be {1}. The given size is {2}");
+    }
+
+    @Override
+    public ViolationMessage COLLECTION_CONTAINS() {
+        return ViolationMessage.of("collection.contains", "\"{0}\" must contain {1}");
+    }
+
+    @Override
+    public ViolationMessage MAP_CONTAINS_VALUE() {
+        return ViolationMessage.of("map.containsValue", "\"{0}\" must contain value {1}");
+    }
+
+    @Override
+    public ViolationMessage MAP_CONTAINS_KEY() {
+        return ViolationMessage.of("map.containsKey", "\"{0}\" must contain key {1}");
+    }
+
+    @Override
+    public ViolationMessage ARRAY_CONTAINS() {
+        return ViolationMessage.of("array.contains", "\"{0}\" must contain {1}");
+    }
+
+    @Override
+    public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
+        return ViolationMessage.of("codePoints.asWhiteList", "\"{1}\" is/are not allowed for \"{0}\"");
+    }
+
+    @Override
+    public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
+        return ViolationMessage.of("codePoints.asBlackList", "\"{1}\" is/are not allowed for \"{0}\"");
+    }
+}

--- a/src/main/java/am/ik/yavi/core/DefaultIncludedViolationMessages.java
+++ b/src/main/java/am/ik/yavi/core/DefaultIncludedViolationMessages.java
@@ -2,161 +2,172 @@ package am.ik.yavi.core;
 
 public class DefaultIncludedViolationMessages extends IncludedViolationMessages {
 
-    @Override
-    public ViolationMessage OBJECT_NOT_NULL() {
-        return ViolationMessage.of("object.notNull", "\"{0}\" must not be null");
-    }
+	@Override
+	public ViolationMessage OBJECT_NOT_NULL() {
+		return ViolationMessage.of("object.notNull", "\"{0}\" must not be null");
+	}
 
-    @Override
-    public ViolationMessage OBJECT_IS_NULL() {
-        return ViolationMessage.of("object.isNull", "\"{0}\" must be null");
-    }
+	@Override
+	public ViolationMessage OBJECT_IS_NULL() {
+		return ViolationMessage.of("object.isNull", "\"{0}\" must be null");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_NOT_EMPTY() {
-        return ViolationMessage.of("container.notEmpty", "\"{0}\" must not be empty");
-    }
+	@Override
+	public ViolationMessage CONTAINER_NOT_EMPTY() {
+		return ViolationMessage.of("container.notEmpty", "\"{0}\" must not be empty");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_LESS_THAN() {
-        return ViolationMessage
-                .of("container.lessThan", "The size of \"{0}\" must be less than {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage CONTAINER_LESS_THAN() {
+		return ViolationMessage.of("container.lessThan",
+				"The size of \"{0}\" must be less than {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
-        return ViolationMessage.of("container.lessThanOrEqual",
-                "The size of \"{0}\" must be less than or equal to {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
+		return ViolationMessage.of("container.lessThanOrEqual",
+				"The size of \"{0}\" must be less than or equal to {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_GREATER_THAN() {
-        return ViolationMessage
-                .of("container.greaterThan", "The size of \"{0}\" must be greater than {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage CONTAINER_GREATER_THAN() {
+		return ViolationMessage.of("container.greaterThan",
+				"The size of \"{0}\" must be greater than {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
-        return ViolationMessage.of("container.greaterThanOrEqual",
-                "The size of \"{0}\" must be greater than or equal to {1}. The given size is" + " {2}");
-    }
+	@Override
+	public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
+		return ViolationMessage.of("container.greaterThanOrEqual",
+				"The size of \"{0}\" must be greater than or equal to {1}. The given size is"
+						+ " {2}");
+	}
 
-    @Override
-    public ViolationMessage CONTAINER_FIXED_SIZE() {
-        return ViolationMessage.of("container.fixedSize", "The size of \"{0}\" must be {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage CONTAINER_FIXED_SIZE() {
+		return ViolationMessage.of("container.fixedSize",
+				"The size of \"{0}\" must be {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage NUMERIC_GREATER_THAN() {
-        return ViolationMessage.of("numeric.greaterThan", "\"{0}\" must be greater than {1}");
-    }
+	@Override
+	public ViolationMessage NUMERIC_GREATER_THAN() {
+		return ViolationMessage.of("numeric.greaterThan",
+				"\"{0}\" must be greater than {1}");
+	}
 
-    @Override
-    public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
-        return ViolationMessage.of("numeric.greaterThanOrEqual", "\"{0}\" must be greater than or equal to {1}");
-    }
+	@Override
+	public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
+		return ViolationMessage.of("numeric.greaterThanOrEqual",
+				"\"{0}\" must be greater than or equal to {1}");
+	}
 
-    @Override
-    public ViolationMessage NUMERIC_LESS_THAN() {
-        return ViolationMessage.of("numeric.lessThan", "\"{0}\" must be less than {1}");
-    }
+	@Override
+	public ViolationMessage NUMERIC_LESS_THAN() {
+		return ViolationMessage.of("numeric.lessThan", "\"{0}\" must be less than {1}");
+	}
 
-    @Override
-    public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
-        return ViolationMessage.of("numeric.lessThanOrEqual", "\"{0}\" must be less than or equal to {1}");
-    }
+	@Override
+	public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
+		return ViolationMessage.of("numeric.lessThanOrEqual",
+				"\"{0}\" must be less than or equal to {1}");
+	}
 
-    @Override
-    public ViolationMessage BOOLEAN_IS_TRUE() {
-        return ViolationMessage.of("boolean.isTrue", "\"{0}\" must be true");
-    }
+	@Override
+	public ViolationMessage BOOLEAN_IS_TRUE() {
+		return ViolationMessage.of("boolean.isTrue", "\"{0}\" must be true");
+	}
 
-    @Override
-    public ViolationMessage BOOLEAN_IS_FALSE() {
-        return ViolationMessage.of("boolean.isFalse", "\"{0}\" must be false");
-    }
+	@Override
+	public ViolationMessage BOOLEAN_IS_FALSE() {
+		return ViolationMessage.of("boolean.isFalse", "\"{0}\" must be false");
+	}
 
-    @Override
-    public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
-        return ViolationMessage.of("charSequence.notBlank", "\"{0}\" must not be blank");
-    }
+	@Override
+	public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
+		return ViolationMessage.of("charSequence.notBlank", "\"{0}\" must not be blank");
+	}
 
-    @Override
-    public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
-        return ViolationMessage.of("charSequence.contains", "\"{0}\" must contain {1}");
-    }
+	@Override
+	public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
+		return ViolationMessage.of("charSequence.contains", "\"{0}\" must contain {1}");
+	}
 
-    @Override
-    public ViolationMessage CHAR_SEQUENCE_EMAIL() {
-        return ViolationMessage.of("charSequence.email", "\"{0}\" must be a valid email address");
-    }
+	@Override
+	public ViolationMessage CHAR_SEQUENCE_EMAIL() {
+		return ViolationMessage.of("charSequence.email",
+				"\"{0}\" must be a valid email address");
+	}
 
-    @Override
-    public ViolationMessage CHAR_SEQUENCE_URL() {
-        return ViolationMessage.of("charSequence.url", "\"{0}\" must be a valid URL");
-    }
+	@Override
+	public ViolationMessage CHAR_SEQUENCE_URL() {
+		return ViolationMessage.of("charSequence.url", "\"{0}\" must be a valid URL");
+	}
 
-    @Override
-    public ViolationMessage CHAR_SEQUENCE_PATTERN() {
-        return ViolationMessage.of("charSequence.pattern", "\"{0}\" must match {1}");
-    }
+	@Override
+	public ViolationMessage CHAR_SEQUENCE_PATTERN() {
+		return ViolationMessage.of("charSequence.pattern", "\"{0}\" must match {1}");
+	}
 
-    @Override
-    public ViolationMessage BYTE_SIZE_LESS_THAN() {
-        return ViolationMessage
-                .of("byteSize.lessThan", "The size of \"{0}\" must be less than {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage BYTE_SIZE_LESS_THAN() {
+		return ViolationMessage.of("byteSize.lessThan",
+				"The size of \"{0}\" must be less than {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
-        return ViolationMessage.of("byteSize.lessThanOrEqual",
-                "The byte size of \"{0}\" must be less than or equal to {1}. The given size is " + "{2}");
-    }
+	@Override
+	public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
+		return ViolationMessage.of("byteSize.lessThanOrEqual",
+				"The byte size of \"{0}\" must be less than or equal to {1}. The given size is "
+						+ "{2}");
+	}
 
-    @Override
-    public ViolationMessage BYTE_SIZE_GREATER_THAN() {
-        return ViolationMessage
-                .of("byteSize.greaterThan", "The byte size of \"{0}\" must be greater than {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage BYTE_SIZE_GREATER_THAN() {
+		return ViolationMessage.of("byteSize.greaterThan",
+				"The byte size of \"{0}\" must be greater than {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
-        return ViolationMessage.of("byteSize.greaterThanOrEqual",
-                "The byte size of \"{0}\" must be greater than or equal to {1}. The given " + "size is {2}");
-    }
+	@Override
+	public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
+		return ViolationMessage.of("byteSize.greaterThanOrEqual",
+				"The byte size of \"{0}\" must be greater than or equal to {1}. The given "
+						+ "size is {2}");
+	}
 
-    @Override
-    public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
-        return ViolationMessage.of("byteSize.fixedSize", "The byte size of \"{0}\" must be {1}. The given size is {2}");
-    }
+	@Override
+	public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
+		return ViolationMessage.of("byteSize.fixedSize",
+				"The byte size of \"{0}\" must be {1}. The given size is {2}");
+	}
 
-    @Override
-    public ViolationMessage COLLECTION_CONTAINS() {
-        return ViolationMessage.of("collection.contains", "\"{0}\" must contain {1}");
-    }
+	@Override
+	public ViolationMessage COLLECTION_CONTAINS() {
+		return ViolationMessage.of("collection.contains", "\"{0}\" must contain {1}");
+	}
 
-    @Override
-    public ViolationMessage MAP_CONTAINS_VALUE() {
-        return ViolationMessage.of("map.containsValue", "\"{0}\" must contain value {1}");
-    }
+	@Override
+	public ViolationMessage MAP_CONTAINS_VALUE() {
+		return ViolationMessage.of("map.containsValue", "\"{0}\" must contain value {1}");
+	}
 
-    @Override
-    public ViolationMessage MAP_CONTAINS_KEY() {
-        return ViolationMessage.of("map.containsKey", "\"{0}\" must contain key {1}");
-    }
+	@Override
+	public ViolationMessage MAP_CONTAINS_KEY() {
+		return ViolationMessage.of("map.containsKey", "\"{0}\" must contain key {1}");
+	}
 
-    @Override
-    public ViolationMessage ARRAY_CONTAINS() {
-        return ViolationMessage.of("array.contains", "\"{0}\" must contain {1}");
-    }
+	@Override
+	public ViolationMessage ARRAY_CONTAINS() {
+		return ViolationMessage.of("array.contains", "\"{0}\" must contain {1}");
+	}
 
-    @Override
-    public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
-        return ViolationMessage.of("codePoints.asWhiteList", "\"{1}\" is/are not allowed for \"{0}\"");
-    }
+	@Override
+	public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
+		return ViolationMessage.of("codePoints.asWhiteList",
+				"\"{1}\" is/are not allowed for \"{0}\"");
+	}
 
-    @Override
-    public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
-        return ViolationMessage.of("codePoints.asBlackList", "\"{1}\" is/are not allowed for \"{0}\"");
-    }
+	@Override
+	public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
+		return ViolationMessage.of("codePoints.asBlackList",
+				"\"{1}\" is/are not allowed for \"{0}\"");
+	}
 }

--- a/src/main/java/am/ik/yavi/core/IncludedViolationMessages.java
+++ b/src/main/java/am/ik/yavi/core/IncludedViolationMessages.java
@@ -1,0 +1,77 @@
+package am.ik.yavi.core;
+
+public abstract class IncludedViolationMessages {
+
+    private static IncludedViolationMessages includedViolationMessages = null;
+
+    public static IncludedViolationMessages get() {
+        if (includedViolationMessages == null) {
+            includedViolationMessages = new DefaultIncludedViolationMessages();
+        }
+        return includedViolationMessages;
+    }
+
+    public static void define(IncludedViolationMessages includedViolationMessages) {
+        IncludedViolationMessages.includedViolationMessages = includedViolationMessages;
+    }
+
+    public abstract ViolationMessage OBJECT_NOT_NULL();
+
+    public abstract ViolationMessage OBJECT_IS_NULL();
+
+    public abstract ViolationMessage CONTAINER_NOT_EMPTY();
+
+    public abstract ViolationMessage CONTAINER_LESS_THAN();
+
+    public abstract ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage CONTAINER_GREATER_THAN();
+
+    public abstract ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage CONTAINER_FIXED_SIZE();
+
+    public abstract ViolationMessage NUMERIC_GREATER_THAN();
+
+    public abstract ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage NUMERIC_LESS_THAN();
+
+    public abstract ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage BOOLEAN_IS_TRUE();
+
+    public abstract ViolationMessage BOOLEAN_IS_FALSE();
+
+    public abstract ViolationMessage CHAR_SEQUENCE_NOT_BLANK();
+
+    public abstract ViolationMessage CHAR_SEQUENCE_CONTAINS();
+
+    public abstract ViolationMessage CHAR_SEQUENCE_EMAIL();
+
+    public abstract ViolationMessage CHAR_SEQUENCE_URL();
+
+    public abstract ViolationMessage CHAR_SEQUENCE_PATTERN();
+
+    public abstract ViolationMessage BYTE_SIZE_LESS_THAN();
+
+    public abstract ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage BYTE_SIZE_GREATER_THAN();
+
+    public abstract ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL();
+
+    public abstract ViolationMessage BYTE_SIZE_FIXED_SIZE();
+
+    public abstract ViolationMessage COLLECTION_CONTAINS();
+
+    public abstract ViolationMessage MAP_CONTAINS_VALUE();
+
+    public abstract ViolationMessage MAP_CONTAINS_KEY();
+
+    public abstract ViolationMessage ARRAY_CONTAINS();
+
+    public abstract ViolationMessage CODE_POINTS_ALL_INCLUDED();
+
+    public abstract ViolationMessage CODE_POINTS_NOT_INCLUDED();
+}

--- a/src/main/java/am/ik/yavi/core/IncludedViolationMessages.java
+++ b/src/main/java/am/ik/yavi/core/IncludedViolationMessages.java
@@ -2,76 +2,76 @@ package am.ik.yavi.core;
 
 public abstract class IncludedViolationMessages {
 
-    private static IncludedViolationMessages includedViolationMessages = null;
+	private static IncludedViolationMessages includedViolationMessages = null;
 
-    public static IncludedViolationMessages get() {
-        if (includedViolationMessages == null) {
-            includedViolationMessages = new DefaultIncludedViolationMessages();
-        }
-        return includedViolationMessages;
-    }
+	public static IncludedViolationMessages get() {
+		if (includedViolationMessages == null) {
+			includedViolationMessages = new DefaultIncludedViolationMessages();
+		}
+		return includedViolationMessages;
+	}
 
-    public static void define(IncludedViolationMessages includedViolationMessages) {
-        IncludedViolationMessages.includedViolationMessages = includedViolationMessages;
-    }
+	public static void define(IncludedViolationMessages includedViolationMessages) {
+		IncludedViolationMessages.includedViolationMessages = includedViolationMessages;
+	}
 
-    public abstract ViolationMessage OBJECT_NOT_NULL();
+	public abstract ViolationMessage OBJECT_NOT_NULL();
 
-    public abstract ViolationMessage OBJECT_IS_NULL();
+	public abstract ViolationMessage OBJECT_IS_NULL();
 
-    public abstract ViolationMessage CONTAINER_NOT_EMPTY();
+	public abstract ViolationMessage CONTAINER_NOT_EMPTY();
 
-    public abstract ViolationMessage CONTAINER_LESS_THAN();
+	public abstract ViolationMessage CONTAINER_LESS_THAN();
 
-    public abstract ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL();
+	public abstract ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage CONTAINER_GREATER_THAN();
+	public abstract ViolationMessage CONTAINER_GREATER_THAN();
 
-    public abstract ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL();
+	public abstract ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage CONTAINER_FIXED_SIZE();
+	public abstract ViolationMessage CONTAINER_FIXED_SIZE();
 
-    public abstract ViolationMessage NUMERIC_GREATER_THAN();
+	public abstract ViolationMessage NUMERIC_GREATER_THAN();
 
-    public abstract ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL();
+	public abstract ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage NUMERIC_LESS_THAN();
+	public abstract ViolationMessage NUMERIC_LESS_THAN();
 
-    public abstract ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL();
+	public abstract ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage BOOLEAN_IS_TRUE();
+	public abstract ViolationMessage BOOLEAN_IS_TRUE();
 
-    public abstract ViolationMessage BOOLEAN_IS_FALSE();
+	public abstract ViolationMessage BOOLEAN_IS_FALSE();
 
-    public abstract ViolationMessage CHAR_SEQUENCE_NOT_BLANK();
+	public abstract ViolationMessage CHAR_SEQUENCE_NOT_BLANK();
 
-    public abstract ViolationMessage CHAR_SEQUENCE_CONTAINS();
+	public abstract ViolationMessage CHAR_SEQUENCE_CONTAINS();
 
-    public abstract ViolationMessage CHAR_SEQUENCE_EMAIL();
+	public abstract ViolationMessage CHAR_SEQUENCE_EMAIL();
 
-    public abstract ViolationMessage CHAR_SEQUENCE_URL();
+	public abstract ViolationMessage CHAR_SEQUENCE_URL();
 
-    public abstract ViolationMessage CHAR_SEQUENCE_PATTERN();
+	public abstract ViolationMessage CHAR_SEQUENCE_PATTERN();
 
-    public abstract ViolationMessage BYTE_SIZE_LESS_THAN();
+	public abstract ViolationMessage BYTE_SIZE_LESS_THAN();
 
-    public abstract ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL();
+	public abstract ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage BYTE_SIZE_GREATER_THAN();
+	public abstract ViolationMessage BYTE_SIZE_GREATER_THAN();
 
-    public abstract ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL();
+	public abstract ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL();
 
-    public abstract ViolationMessage BYTE_SIZE_FIXED_SIZE();
+	public abstract ViolationMessage BYTE_SIZE_FIXED_SIZE();
 
-    public abstract ViolationMessage COLLECTION_CONTAINS();
+	public abstract ViolationMessage COLLECTION_CONTAINS();
 
-    public abstract ViolationMessage MAP_CONTAINS_VALUE();
+	public abstract ViolationMessage MAP_CONTAINS_VALUE();
 
-    public abstract ViolationMessage MAP_CONTAINS_KEY();
+	public abstract ViolationMessage MAP_CONTAINS_KEY();
 
-    public abstract ViolationMessage ARRAY_CONTAINS();
+	public abstract ViolationMessage ARRAY_CONTAINS();
 
-    public abstract ViolationMessage CODE_POINTS_ALL_INCLUDED();
+	public abstract ViolationMessage CODE_POINTS_ALL_INCLUDED();
 
-    public abstract ViolationMessage CODE_POINTS_NOT_INCLUDED();
+	public abstract ViolationMessage CODE_POINTS_NOT_INCLUDED();
 }

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -17,21 +17,21 @@ package am.ik.yavi.core;
 
 public interface ViolationMessage {
 
-    public static ViolationMessage of(String messageKey, String defaultMessageFormat) {
-        return new ViolationMessage() {
-            @Override
-            public String defaultMessageFormat() {
-                return defaultMessageFormat;
-            }
+	public static ViolationMessage of(String messageKey, String defaultMessageFormat) {
+		return new ViolationMessage() {
+			@Override
+			public String defaultMessageFormat() {
+				return defaultMessageFormat;
+			}
 
-            @Override
-            public String messageKey() {
-                return messageKey;
-            }
-        };
-    }
+			@Override
+			public String messageKey() {
+				return messageKey;
+			}
+		};
+	}
 
-    String defaultMessageFormat();
+	String defaultMessageFormat();
 
-    String messageKey();
+	String messageKey();
 }

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -16,88 +16,22 @@
 package am.ik.yavi.core;
 
 public interface ViolationMessage {
-	static ViolationMessage of(String messageKey, String defaultMessageFormat) {
-		return new ViolationMessage() {
-			@Override
-			public String defaultMessageFormat() {
-				return defaultMessageFormat;
-			}
 
-			@Override
-			public String messageKey() {
-				return messageKey;
-			}
-		};
-	}
+    public static ViolationMessage of(String messageKey, String defaultMessageFormat) {
+        return new ViolationMessage() {
+            @Override
+            public String defaultMessageFormat() {
+                return defaultMessageFormat;
+            }
 
-	String defaultMessageFormat();
+            @Override
+            public String messageKey() {
+                return messageKey;
+            }
+        };
+    }
 
-	String messageKey();
+    String defaultMessageFormat();
 
-	enum Default implements ViolationMessage {
-		OBJECT_NOT_NULL("object.notNull", "\"{0}\" must not be null"), //
-		OBJECT_IS_NULL("object.isNull", "\"{0}\" must be null"), //
-		CONTAINER_NOT_EMPTY("container.notEmpty", "\"{0}\" must not be empty"), //
-		CONTAINER_LESS_THAN("container.lessThan",
-				"The size of \"{0}\" must be less than {1}. The given size is {2}"), //
-		CONTAINER_LESS_THAN_OR_EQUAL("container.lessThanOrEqual",
-				"The size of \"{0}\" must be less than or equal to {1}. The given size is {2}"), //
-		CONTAINER_GREATER_THAN("container.greaterThan",
-				"The size of \"{0}\" must be greater than {1}. The given size is {2}"), //
-		CONTAINER_GREATER_THAN_OR_EQUAL("container.greaterThanOrEqual",
-				"The size of \"{0}\" must be greater than or equal to {1}. The given size is {2}"), //
-		CONTAINER_FIXED_SIZE("container.fixedSize",
-				"The size of \"{0}\" must be {1}. The given size is {2}"), //
-		NUMERIC_GREATER_THAN("numeric.greaterThan", "\"{0}\" must be greater than {1}"), //
-		NUMERIC_GREATER_THAN_OR_EQUAL("numeric.greaterThanOrEqual",
-				"\"{0}\" must be greater than or equal to {1}"), //
-		NUMERIC_LESS_THAN("numeric.lessThan", "\"{0}\" must be less than {1}"), //
-		NUMERIC_LESS_THAN_OR_EQUAL("numeric.lessThanOrEqual",
-				"\"{0}\" must be less than or equal to {1}"), //
-		BOOLEAN_IS_TRUE("boolean.isTrue", "\"{0}\" must be true"), //
-		BOOLEAN_IS_FALSE("boolean.isFalse", "\"{0}\" must be false"), //
-		CHAR_SEQUENCE_NOT_BLANK("charSequence.notBlank", "\"{0}\" must not be blank"), //
-		CHAR_SEQUENCE_CONTAINS("charSequence.contains", "\"{0}\" must contain {1}"), //
-		CHAR_SEQUENCE_EMAIL("charSequence.email",
-				"\"{0}\" must be a valid email address"), //
-		CHAR_SEQUENCE_URL("charSequence.url", "\"{0}\" must be a valid URL"), //
-		CHAR_SEQUENCE_PATTERN("charSequence.pattern", "\"{0}\" must match {1}"), //
-		BYTE_SIZE_LESS_THAN("byteSize.lessThan",
-				"The size of \"{0}\" must be less than {1}. The given size is {2}"), //
-		BYTE_SIZE_LESS_THAN_OR_EQUAL("byteSize.lessThanOrEqual",
-				"The byte size of \"{0}\" must be less than or equal to {1}. The given size is {2}"), //
-		BYTE_SIZE_GREATER_THAN("byteSize.greaterThan",
-				"The byte size of \"{0}\" must be greater than {1}. The given size is {2}"), //
-		BYTE_SIZE_GREATER_THAN_OR_EQUAL("byteSize.greaterThanOrEqual",
-				"The byte size of \"{0}\" must be greater than or equal to {1}. The given size is {2}"), //
-		BYTE_SIZE_FIXED_SIZE("byteSize.fixedSize",
-				"The byte size of \"{0}\" must be {1}. The given size is {2}"), //
-		COLLECTION_CONTAINS("collection.contains", "\"{0}\" must contain {1}"), //
-		MAP_CONTAINS_VALUE("map.containsValue", "\"{0}\" must contain value {1}"), //
-		MAP_CONTAINS_KEY("map.containsKey", "\"{0}\" must contain key {1}"), //
-		ARRAY_CONTAINS("array.contains", "\"{0}\" must contain {1}"), //
-		CODE_POINTS_ALL_INCLUDED("codePoints.asWhiteList",
-				"\"{1}\" is/are not allowed for \"{0}\""), //
-		CODE_POINTS_NOT_INCLUDED("codePoints.asBlackList",
-				"\"{1}\" is/are not allowed for \"{0}\"");
-
-		private final String defaultMessageFormat;
-
-		private final String messageKey;
-
-		Default(String messageKey, String defaultMessageFormat) {
-			this.messageKey = messageKey;
-			this.defaultMessageFormat = defaultMessageFormat;
-		}
-
-		@Override
-		public String defaultMessageFormat() {
-			return this.defaultMessageFormat;
-		}
-
-		@Override
-		public String messageKey() {
-			return this.messageKey;
-		}
-	}
+    String messageKey();
 }

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -36,755 +36,851 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class ValidatorTest {
 
-    public static final IncludedViolationMessages germanViolationMessages = new IncludedViolationMessages() {
-        @Override
-        public ViolationMessage OBJECT_NOT_NULL() {
-            return ViolationMessage.of("notnulll", "Für \"{0}\" muss ein Wert vorhanden sein.");
-        }
-
-        @Override
-        public ViolationMessage OBJECT_IS_NULL() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_NOT_EMPTY() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_LESS_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
-            return ViolationMessage.of("container.lessThanOrEqual",
-                    "Die Länge von \"{0}\" muss kleiner oder gleich {1} sein. Aktuelle Länge ist {2}.");
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_GREATER_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
-            return ViolationMessage.of("container.greaterThanOrEqual",
-                    "Die Länge von \"{0}\" muss größer oder gleich {1} sein. Aktuelle Länge ist {2}.");
-        }
-
-        @Override
-        public ViolationMessage CONTAINER_FIXED_SIZE() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage NUMERIC_GREATER_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
-            return ViolationMessage.of("numeric.greaterThanOrEqual", "\"{0}\" muss größer gleich {1} sein.");
-        }
-
-        @Override
-        public ViolationMessage NUMERIC_LESS_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
-            return ViolationMessage.of("numeric.lessThanOrEqual", "\"{0}\" muss kleiner gleich {1} sein.");
-        }
-
-        @Override
-        public ViolationMessage BOOLEAN_IS_TRUE() {
-            return ViolationMessage.of("boolean.isTrue", "\"{0}\" muss wahr sein.");
-        }
-
-        @Override
-        public ViolationMessage BOOLEAN_IS_FALSE() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CHAR_SEQUENCE_EMAIL() {
-            return ViolationMessage.of("charSequence.email", "\"{0}\" muss eine gültige E-Mail Adresse sein.");
-        }
-
-        @Override
-        public ViolationMessage CHAR_SEQUENCE_URL() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CHAR_SEQUENCE_PATTERN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage BYTE_SIZE_LESS_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage BYTE_SIZE_GREATER_THAN() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage COLLECTION_CONTAINS() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage MAP_CONTAINS_VALUE() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage MAP_CONTAINS_KEY() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage ARRAY_CONTAINS() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
-            return null;
-        }
-
-        @Override
-        public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
-            return null;
-        }
-    };
-
-    @Test
-    public void allInvalid() throws Exception {
-        User user = new User("", "example.com", 300);
-        user.setEnabled(false);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(4);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The size of \"name\" must be greater than or equal to 1. The given size is 0");
-        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
-        assertThat(violations.get(1).message()).isEqualTo("\"email\" must be a valid email address");
-        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
-        assertThat(violations.get(2).message()).isEqualTo("\"age\" must be less than or equal to 200");
-        assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
-        assertThat(violations.get(3).message()).isEqualTo("\"enabled\" must be true");
-        assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
-    }
-
-    Validator<User> validator() {
-        return ValidatorBuilder.<User>of() //
-                .constraint(User::getName, "name", c -> c.notNull() //
-                        .greaterThanOrEqual(1) //
-                        .lessThanOrEqual(20)) //
-                .constraint(User::getEmail, "email", c -> c.notNull() //
-                        .greaterThanOrEqual(5) //
-                        .lessThanOrEqual(50) //
-                        .email()) //
-                .constraint(User::getAge, "age", c -> c.notNull() //
-                        .greaterThanOrEqual(0) //
-                        .lessThanOrEqual(200)) //
-                .constraint(User::isEnabled, "enabled", c -> c.isTrue()) //
-                .build();
-    }
-
-    @Test
-    public void allInvalidCustomIncludedViolationMessages() throws Exception {
-        IncludedViolationMessages.define(germanViolationMessages);
-        User user = new User("", "example.com", 300);
-        user.setEnabled(false);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(4);
-        assertThat(violations.get(0).message())
-                .isEqualTo("Die Länge von \"name\" muss größer oder gleich 1 sein. Aktuelle Länge ist 0.");
-        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
-        assertThat(violations.get(1).message()).isEqualTo("\"email\" muss eine gültige E-Mail Adresse sein.");
-        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
-        assertThat(violations.get(2).message()).isEqualTo("\"age\" muss kleiner gleich 200 sein.");
-        assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
-        assertThat(violations.get(3).message()).isEqualTo("\"enabled\" muss wahr sein.");
-        assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
-        IncludedViolationMessages.define(new DefaultIncludedViolationMessages());
-    }
-
-    @Test
-    public void codePointsAllIncludedRange() throws Exception {
-        CodePointsRanges<String> whiteList = () -> Arrays.asList(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
-                CodePoints.Range.of(0x0061/* a */, 0x007A /* z */));
-        User user = new User("abc@b.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-    }
-
-    @Test
-    public void codePointsAllIncludedRangeBeginToEnd() throws Exception {
-        User user = new User("abc@b.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(0x0041/* A */, 0x007A /* z */).asWhiteList())
-                .build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-    }
-
-    @Test
-    public void codePointsAllIncludedRangeRange() throws Exception {
-        User user = new User("abc@b.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
-                c -> c.codePoints(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
-                        CodePoints.Range.of(0x0061/* a */, 0x007A /* z */)).asWhiteList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-    }
-
-    @Test
-    public void codePointsAllIncludedSet() throws Exception {
-        CodePointsSet<String> whiteList = () -> new HashSet<>(
-                Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */, 0x0044 /* D */, 0x0045 /* E */,
-                        0x0046 /* F */, 0x0047 /* G */, 0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
-                        0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */, 0x0050 /* P */, 0x0051 /* Q */,
-                        0x0052 /* R */, 0x0053 /* S */, 0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
-                        0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
-                        0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */, 0x0065 /* e */, 0x0066 /* f */,
-                        0x0067 /* g */, 0x0068 /* h */, 0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
-                        0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */, 0x0071 /* q */, 0x0072 /* r */,
-                        0x0073 /* s */, 0x0074 /* t */, 0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
-                        0x0079 /* y */, 0x007A /* z */));
-        User user = new User("abc@b.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-    }
-
-    @Test
-    public void codePointsAllIncludedSetSet() throws Exception {
-        Set<Integer> whiteList = new HashSet<>(
-                Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */, 0x0044 /* D */, 0x0045 /* E */,
-                        0x0046 /* F */, 0x0047 /* G */, 0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
-                        0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */, 0x0050 /* P */, 0x0051 /* Q */,
-                        0x0052 /* R */, 0x0053 /* S */, 0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
-                        0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
-                        0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */, 0x0065 /* e */, 0x0066 /* f */,
-                        0x0067 /* g */, 0x0068 /* h */, 0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
-                        0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */, 0x0071 /* q */, 0x0072 /* r */,
-                        0x0073 /* s */, 0x0074 /* t */, 0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
-                        0x0079 /* y */, 0x007A /* z */));
-        User user = new User("abc@b.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-    }
-
-    @Test
-    public void codePointsNotIncludedRange() throws Exception {
-        CodePointsRanges<String> blackList = () -> Arrays.asList(CodePoints.Range.of(0x0041/* A */, 0x0042 /* B */),
-                CodePoints.Range.of(0x0061/* a */, 0x0062 /* b */));
-        User user = new User("abcA@Bb.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(blackList).asBlackList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[a, b, A, B]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
-    }
-
-    @Test
-    public void codePointsNotIncludedSet() throws Exception {
-        CodePointsSet<String> blackList = () -> new HashSet<>(Arrays.asList(0x0061 /* a */, 0x0062 /* b */));
-        User user = new User("abcA@Bb.c", null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.codePoints(blackList).asBlackList()).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"[a, b]\" is/are not allowed for \"name\"");
-        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
-    }
-
-    @Test
-    public void combiningCharacterByteSizeInValid() throws Exception {
-        User user = new User("モジ" /* モシ\u3099 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.lessThanOrEqual(2).asByteArray().lessThanOrEqual(6)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The byte size of \"name\" must be less than or equal to 6. The given size is 9");
-    }
-
-    @Test
-    public void combiningCharacterSizeAndByteSizeInValid() throws Exception {
-        User user = new User("モジ" /* モシ\u3099 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.lessThanOrEqual(1).asByteArray().lessThanOrEqual(3)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(2);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The size of \"name\" must be less than or equal to 1. The given size is 2");
-        assertThat(violations.get(1).message())
-                .isEqualTo("The byte size of \"name\" must be less than or equal to 3. The given size is 9");
-    }
-
-    @Test
-    public void combiningCharacterValid() throws Exception {
-        User user = new User("モジ" /* モシ\u3099 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.fixedSize(2).asByteArray().fixedSize(9)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isTrue();
-    }
-
-    @Test
-    public void condition() {
-        Validator<User> validator = ValidatorBuilder.of(User.class) //
-                .constraintOnCondition((u, cg) -> !u.getName().isEmpty(), //
-                        b -> b.constraint(User::getEmail, "email", c -> c.email().notEmpty())).build();
-        {
-            User user = new User("", "", -1);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isTrue();
-        }
-        {
-            User user = new User("foobar", "", -1);
-            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("\"email\" must not be empty");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.notEmpty");
-        }
-    }
-
-    @Test
-    public void constraintOnTarget() {
-        Validator<Range> validator = ValidatorBuilder.of(Range.class) //
-                .constraintOnTarget(Range::isToGreaterThanFrom, "to", "to.isGreaterThanFrom",
-                        "\"to\" must be greater than \"from\".") //
-                .build();
-        {
-            Range range = new Range(1, 10);
-            ConstraintViolations violations = validator.validate(range);
-            assertThat(violations.isValid()).isTrue();
-        }
-        {
-            Range range = new Range(10, 1);
-            ConstraintViolations violations = validator.validate(range);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("\"to\" must be greater than \"from\".");
-            assertThat(violations.get(0).messageKey()).isEqualTo("to.isGreaterThanFrom");
-        }
-    }
-
-    @Test
-    public void customMessageFormatter() throws Exception {
-        Validator<User> validator = ValidatorBuilder.of(User.class).messageFormatter(
-                (messageKey, defaultMessageFormat, args, locale) -> args[0].toString().toUpperCase() + "." +
-                        messageKey.toUpperCase()).constraint(User::getAge, "age", c -> c.notNull() //
-                .greaterThanOrEqual(0) //
-                .lessThanOrEqual(20)).build();
-        User user = new User("foo", "foo@example.com", 30);
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("AGE.NUMERIC.LESSTHANOREQUAL");
-        assertThat(violations.get(0).messageKey()).isEqualTo("numeric.lessThanOrEqual");
-    }
-
-    @Test
-    public void details() throws Exception {
-        User user = new User("", "example.com", 300);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        List<ViolationDetail> details = violations.details();
-        assertThat(details.size()).isEqualTo(3);
-        assertThat(details.get(0).getDefaultMessage())
-                .isEqualTo("The size of \"name\" must be greater than or equal to 1. The given size is 0");
-        assertThat(details.get(0).getKey()).isEqualTo("container.greaterThanOrEqual");
-        assertThat(details.get(0).getArgs()).containsExactly("name", 1, 0);
-        assertThat(details.get(1).getDefaultMessage()).isEqualTo("\"email\" must be a valid email address");
-        assertThat(details.get(1).getKey()).isEqualTo("charSequence.email");
-        assertThat(details.get(1).getArgs()).containsExactly("email", "example.com");
-        assertThat(details.get(2).getDefaultMessage()).isEqualTo("\"age\" must be less than or equal to 200");
-        assertThat(details.get(2).getKey()).isEqualTo("numeric.lessThanOrEqual");
-        assertThat(details.get(2).getArgs()).containsExactly("age", 200, 300);
-    }
-
-    @Test
-    public void emojiInValid() throws Exception {
-        User user = new User("I❤️☕️", null, null);
-        Validator<User> validator =
-                ValidatorBuilder.of(User.class).constraint(User::getName, "name", c -> c.emoji().greaterThan(3))
-                        .build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The size of \"name\" must be greater than 3. The given size is 3");
-    }
-
-    @Test
-    public void emojiValid() throws Exception {
-        User user = new User("I❤️☕️", null, null);
-        Validator<User> validator =
-                ValidatorBuilder.of(User.class).constraint(User::getName, "name", c -> c.emoji().lessThanOrEqual(3))
-                        .build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isTrue();
-    }
-
-    @Test
-    public void group() {
-        User user = new User("foobar", "foo@example.com", -1);
-        Validator<User> validator = ValidatorBuilder.of(User.class) //
-                .constraintOnCondition(Group.UPDATE.toCondition(), //
-                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
-        {
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isTrue();
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-    }
-
-    @Test
-    public void groupConditionByGroup() {
-        User user = new User("foobar", "foo@example.com", -1);
-        Validator<User> validator = ValidatorBuilder.of(User.class) //
-                .constraintOnCondition((u, cg) -> cg == Group.UPDATE || cg == Group.DELETE, //
-                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
-        {
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isTrue();
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.DELETE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-    }
-
-    @Test
-    public void groupTwoCondition() {
-        User user = new User("foobar", "foo@example.com", -1);
-        Validator<User> validator = ValidatorBuilder.of(User.class) //
-                .constraintOnGroup(Group.UPDATE, //
-                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5)))
-                .constraintOnGroup(Group.DELETE, //
-                        b -> b.constraint(User::getName, "name", c -> c.greaterThanOrEqual(5))).build();
-        {
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isTrue();
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.DELETE);
-            assertThat(violations.isValid()).isTrue();
-        }
-    }
-
-    @Test
-    public void ivsByteSizeInValid() throws Exception {
-        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
-                c -> c.variant(opts -> opts.ivs(IGNORE)).lessThanOrEqual(3).asByteArray().lessThanOrEqual(12)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The byte size of \"name\" must be less than or equal to 12. The given size is 13");
-    }
-
-    @Test
-    public void ivsInValid() throws Exception {
-        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.fixedSize(3).asByteArray().fixedSize(13)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("The size of \"name\" must be 3. The given size is 4");
-    }
-
-    @Test
-    public void ivsSizeAndByteSizeInValid() throws Exception {
-        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class)
-                .constraint(User::getName, "name", c -> c.lessThanOrEqual(3).asByteArray().lessThanOrEqual(12)).build();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(2);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The size of \"name\" must be less than or equal to 3. The given size is 4");
-        assertThat(violations.get(1).message())
-                .isEqualTo("The byte size of \"name\" must be less than or equal to 12. The given size is 13");
-    }
-
-    @Test
-    public void ivsValid() throws Exception {
-        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
-                c -> c.variant(opts -> opts.ivs(IGNORE)).fixedSize(3).asByteArray().fixedSize(13)).build();
-        ConstraintViolations violations = validator.validate(user);
-        violations.forEach(x -> System.out.println(x.message()));
-        assertThat(violations.isValid()).isTrue();
-    }
-
-    @Test
-    public void multipleViolationOnOneProperty() throws Exception {
-        User user = new User("foo", "aa", 200);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(2);
-        assertThat(violations.get(0).message())
-                .isEqualTo("The size of \"email\" must be greater than or equal to 5. The given size is 2");
-        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
-        assertThat(violations.get(1).message()).isEqualTo("\"email\" must be a valid email address");
-        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
-    }
-
-    @Test
-    public void nullValues() throws Exception {
-        User user = new User(null, null, null);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(3);
-        assertThat(violations.get(0).message()).isEqualTo("\"name\" must not be null");
-        assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
-        assertThat(violations.get(1).message()).isEqualTo("\"email\" must not be null");
-        assertThat(violations.get(1).messageKey()).isEqualTo("object.notNull");
-        assertThat(violations.get(2).message()).isEqualTo("\"age\" must not be null");
-        assertThat(violations.get(2).messageKey()).isEqualTo("object.notNull");
-    }
-
-    @Test
-    public void overrideMessage() {
-        Validator<User> validator = ValidatorBuilder.<User>of() //
-                .constraint(User::getName, "name", c -> c.notNull().message("name is required!") //
-                        .greaterThanOrEqual(1).message("name is too small!") //
-                        .lessThanOrEqual(20).message("name is too large!")) //
-                .build();
-        {
-            User user = new User(null, "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is required!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
-        }
-        {
-            User user = new User("", "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is too small!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
-        }
-        {
-            User user = new User("012345678901234567890", "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is too large!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-    }
-
-    @Test
-    public void overrideViolationMessage() {
-        Validator<User> validator = ValidatorBuilder.<User>of() //
-                .constraint(User::getName, "name",
-                        c -> c.notNull().message(ViolationMessage.of("a", "name is required!")) //
-                                .greaterThanOrEqual(1).message(ViolationMessage.of("b", "name is too small!")) //
-                                .lessThanOrEqual(20).message(ViolationMessage.of("c", "name is too large!"))) //
-                .build();
-        {
-            User user = new User(null, "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is required!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("a");
-        }
-        {
-            User user = new User("", "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is too small!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("b");
-        }
-        {
-            User user = new User("012345678901234567890", "a@b.c", 10);
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("name is too large!");
-            assertThat(violations.get(0).messageKey()).isEqualTo("c");
-        }
-    }
-
-    @Test
-    public void throwIfInValidInValid() throws Exception {
-        User user = new User("foo", "foo@example.com", -1);
-        try {
-            validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
-            fail("fail");
-        } catch (ConstraintViolationsException e) {
-            ConstraintViolations violations = e.getViolations();
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message()).isEqualTo("\"age\" must be greater than or equal to 0");
-            assertThat(violations.get(0).messageKey()).isEqualTo("numeric.greaterThanOrEqual");
-        }
-    }
-
-    @Test
-    public void throwIfInValidValid() throws Exception {
-        User user = new User("foo", "foo@example.com", 30);
-        validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
-    }
-
-    @Test
-    public void valid() throws Exception {
-        User user = new User("foo", "foo@example.com", 30);
-        Validator<User> validator = validator();
-        ConstraintViolations violations = validator.validate(user);
-        assertThat(violations.isValid()).isTrue();
-    }
-
-    @Test
-    public void validateToEitherInValid() throws Exception {
-        User user = new User("foo", "foo@example.com", -1);
-        Either<ConstraintViolations, User> either = validator().validateToEither(user);
-        assertThat(either.isLeft()).isTrue();
-        ConstraintViolations violations = either.left().get();
-        assertThat(violations.isValid()).isFalse();
-        assertThat(violations.size()).isEqualTo(1);
-        assertThat(violations.get(0).message()).isEqualTo("\"age\" must be greater than or equal to 0");
-        assertThat(violations.get(0).messageKey()).isEqualTo("numeric.greaterThanOrEqual");
-    }
-
-    @Test
-    public void validateToEitherValid() throws Exception {
-        User user = new User("foo", "foo@example.com", 30);
-        Either<ConstraintViolations, User> either = validator().validateToEither(user);
-        assertThat(either.isRight()).isTrue();
-        assertThat(either.right().get()).isSameAs(user);
-    }
-
-    @Test
-    public void violateGroupAndDefault() {
-        User user = new User("foobar", "foo@example.com", -1);
-        Validator<User> validator = ValidatorBuilder.of(User.class) //
-                .constraint(User::getEmail, "email", c -> c.email().lessThanOrEqual(10))
-                .constraintOnGroup(Group.UPDATE, //
-                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
-        {
-            ConstraintViolations violations = validator.validate(user);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(1);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"email\" must be less than or equal to 10. The given size is 15");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-        {
-            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-            assertThat(violations.isValid()).isFalse();
-            assertThat(violations.size()).isEqualTo(2);
-            assertThat(violations.get(0).message())
-                    .isEqualTo("The size of \"email\" must be less than or equal to 10. The given size is 15");
-            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
-            assertThat(violations.get(1).message())
-                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
-            assertThat(violations.get(1).messageKey()).isEqualTo("container.lessThanOrEqual");
-        }
-    }
+	public static final IncludedViolationMessages germanViolationMessages = new IncludedViolationMessages() {
+		@Override
+		public ViolationMessage OBJECT_NOT_NULL() {
+			return ViolationMessage.of("notnulll",
+					"Für \"{0}\" muss ein Wert vorhanden sein.");
+		}
+
+		@Override
+		public ViolationMessage OBJECT_IS_NULL() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_NOT_EMPTY() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_LESS_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
+			return ViolationMessage.of("container.lessThanOrEqual",
+					"Die Länge von \"{0}\" muss kleiner oder gleich {1} sein. Aktuelle Länge ist {2}.");
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_GREATER_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
+			return ViolationMessage.of("container.greaterThanOrEqual",
+					"Die Länge von \"{0}\" muss größer oder gleich {1} sein. Aktuelle Länge ist {2}.");
+		}
+
+		@Override
+		public ViolationMessage CONTAINER_FIXED_SIZE() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage NUMERIC_GREATER_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
+			return ViolationMessage.of("numeric.greaterThanOrEqual",
+					"\"{0}\" muss größer gleich {1} sein.");
+		}
+
+		@Override
+		public ViolationMessage NUMERIC_LESS_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
+			return ViolationMessage.of("numeric.lessThanOrEqual",
+					"\"{0}\" muss kleiner gleich {1} sein.");
+		}
+
+		@Override
+		public ViolationMessage BOOLEAN_IS_TRUE() {
+			return ViolationMessage.of("boolean.isTrue", "\"{0}\" muss wahr sein.");
+		}
+
+		@Override
+		public ViolationMessage BOOLEAN_IS_FALSE() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CHAR_SEQUENCE_EMAIL() {
+			return ViolationMessage.of("charSequence.email",
+					"\"{0}\" muss eine gültige E-Mail Adresse sein.");
+		}
+
+		@Override
+		public ViolationMessage CHAR_SEQUENCE_URL() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CHAR_SEQUENCE_PATTERN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage BYTE_SIZE_LESS_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage BYTE_SIZE_GREATER_THAN() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage COLLECTION_CONTAINS() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage MAP_CONTAINS_VALUE() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage MAP_CONTAINS_KEY() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage ARRAY_CONTAINS() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
+			return null;
+		}
+
+		@Override
+		public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
+			return null;
+		}
+	};
+
+	@Test
+	public void allInvalid() throws Exception {
+		User user = new User("", "example.com", 300);
+		user.setEnabled(false);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(4);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"name\" must be greater than or equal to 1. The given size is 0");
+		assertThat(violations.get(0).messageKey())
+				.isEqualTo("container.greaterThanOrEqual");
+		assertThat(violations.get(1).message())
+				.isEqualTo("\"email\" must be a valid email address");
+		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+		assertThat(violations.get(2).message())
+				.isEqualTo("\"age\" must be less than or equal to 200");
+		assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+		assertThat(violations.get(3).message()).isEqualTo("\"enabled\" must be true");
+		assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
+	}
+
+	Validator<User> validator() {
+		return ValidatorBuilder.<User> of() //
+				.constraint(User::getName, "name", c -> c.notNull() //
+						.greaterThanOrEqual(1) //
+						.lessThanOrEqual(20)) //
+				.constraint(User::getEmail, "email", c -> c.notNull() //
+						.greaterThanOrEqual(5) //
+						.lessThanOrEqual(50) //
+						.email()) //
+				.constraint(User::getAge, "age", c -> c.notNull() //
+						.greaterThanOrEqual(0) //
+						.lessThanOrEqual(200)) //
+				.constraint(User::isEnabled, "enabled", c -> c.isTrue()) //
+				.build();
+	}
+
+	@Test
+	public void allInvalidCustomIncludedViolationMessages() throws Exception {
+		IncludedViolationMessages.define(germanViolationMessages);
+		User user = new User("", "example.com", 300);
+		user.setEnabled(false);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(4);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"Die Länge von \"name\" muss größer oder gleich 1 sein. Aktuelle Länge ist 0.");
+		assertThat(violations.get(0).messageKey())
+				.isEqualTo("container.greaterThanOrEqual");
+		assertThat(violations.get(1).message())
+				.isEqualTo("\"email\" muss eine gültige E-Mail Adresse sein.");
+		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+		assertThat(violations.get(2).message())
+				.isEqualTo("\"age\" muss kleiner gleich 200 sein.");
+		assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+		assertThat(violations.get(3).message()).isEqualTo("\"enabled\" muss wahr sein.");
+		assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
+		IncludedViolationMessages.define(new DefaultIncludedViolationMessages());
+	}
+
+	@Test
+	public void codePointsAllIncludedRange() throws Exception {
+		CodePointsRanges<String> whiteList = () -> Arrays.asList(
+				CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
+				CodePoints.Range.of(0x0061/* a */, 0x007A /* z */));
+		User user = new User("abc@b.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(whiteList).asWhiteList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+	}
+
+	@Test
+	public void codePointsAllIncludedRangeBeginToEnd() throws Exception {
+		User user = new User("abc@b.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(0x0041/* A */, 0x007A /* z */).asWhiteList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+	}
+
+	@Test
+	public void codePointsAllIncludedRangeRange() throws Exception {
+		User user = new User("abc@b.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class).constraint(
+				User::getName, "name",
+				c -> c.codePoints(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
+						CodePoints.Range.of(0x0061/* a */, 0x007A /* z */)).asWhiteList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+	}
+
+	@Test
+	public void codePointsAllIncludedSet() throws Exception {
+		CodePointsSet<String> whiteList = () -> new HashSet<>(
+				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
+						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
+						0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
+						0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */,
+						0x0050 /* P */, 0x0051 /* Q */, 0x0052 /* R */, 0x0053 /* S */,
+						0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
+						0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
+						0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */,
+						0x0065 /* e */, 0x0066 /* f */, 0x0067 /* g */, 0x0068 /* h */,
+						0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
+						0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */,
+						0x0071 /* q */, 0x0072 /* r */, 0x0073 /* s */, 0x0074 /* t */,
+						0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
+						0x0079 /* y */, 0x007A /* z */));
+		User user = new User("abc@b.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(whiteList).asWhiteList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+	}
+
+	@Test
+	public void codePointsAllIncludedSetSet() throws Exception {
+		Set<Integer> whiteList = new HashSet<>(
+				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
+						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
+						0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
+						0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */,
+						0x0050 /* P */, 0x0051 /* Q */, 0x0052 /* R */, 0x0053 /* S */,
+						0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
+						0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
+						0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */,
+						0x0065 /* e */, 0x0066 /* f */, 0x0067 /* g */, 0x0068 /* h */,
+						0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
+						0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */,
+						0x0071 /* q */, 0x0072 /* r */, 0x0073 /* s */, 0x0074 /* t */,
+						0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
+						0x0079 /* y */, 0x007A /* z */));
+		User user = new User("abc@b.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(whiteList).asWhiteList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+	}
+
+	@Test
+	public void codePointsNotIncludedRange() throws Exception {
+		CodePointsRanges<String> blackList = () -> Arrays.asList(
+				CodePoints.Range.of(0x0041/* A */, 0x0042 /* B */),
+				CodePoints.Range.of(0x0061/* a */, 0x0062 /* b */));
+		User user = new User("abcA@Bb.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(blackList).asBlackList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[a, b, A, B]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
+	}
+
+	@Test
+	public void codePointsNotIncludedSet() throws Exception {
+		CodePointsSet<String> blackList = () -> new HashSet<>(
+				Arrays.asList(0x0061 /* a */, 0x0062 /* b */));
+		User user = new User("abcA@Bb.c", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.codePoints(blackList).asBlackList())
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"[a, b]\" is/are not allowed for \"name\"");
+		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
+	}
+
+	@Test
+	public void combiningCharacterByteSizeInValid() throws Exception {
+		User user = new User("モジ" /* モシ\u3099 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.lessThanOrEqual(2).asByteArray().lessThanOrEqual(6))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The byte size of \"name\" must be less than or equal to 6. The given size is 9");
+	}
+
+	@Test
+	public void combiningCharacterSizeAndByteSizeInValid() throws Exception {
+		User user = new User("モジ" /* モシ\u3099 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.lessThanOrEqual(1).asByteArray().lessThanOrEqual(3))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(2);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"name\" must be less than or equal to 1. The given size is 2");
+		assertThat(violations.get(1).message()).isEqualTo(
+				"The byte size of \"name\" must be less than or equal to 3. The given size is 9");
+	}
+
+	@Test
+	public void combiningCharacterValid() throws Exception {
+		User user = new User("モジ" /* モシ\u3099 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.fixedSize(2).asByteArray().fixedSize(9))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void condition() {
+		Validator<User> validator = ValidatorBuilder.of(User.class) //
+				.constraintOnCondition((u, cg) -> !u.getName().isEmpty(), //
+						b -> b.constraint(User::getEmail, "email",
+								c -> c.email().notEmpty()))
+				.build();
+		{
+			User user = new User("", "", -1);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isTrue();
+		}
+		{
+			User user = new User("foobar", "", -1);
+			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message())
+					.isEqualTo("\"email\" must not be empty");
+			assertThat(violations.get(0).messageKey()).isEqualTo("container.notEmpty");
+		}
+	}
+
+	@Test
+	public void constraintOnTarget() {
+		Validator<Range> validator = ValidatorBuilder.of(Range.class) //
+				.constraintOnTarget(Range::isToGreaterThanFrom, "to",
+						"to.isGreaterThanFrom", "\"to\" must be greater than \"from\".") //
+				.build();
+		{
+			Range range = new Range(1, 10);
+			ConstraintViolations violations = validator.validate(range);
+			assertThat(violations.isValid()).isTrue();
+		}
+		{
+			Range range = new Range(10, 1);
+			ConstraintViolations violations = validator.validate(range);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message())
+					.isEqualTo("\"to\" must be greater than \"from\".");
+			assertThat(violations.get(0).messageKey()).isEqualTo("to.isGreaterThanFrom");
+		}
+	}
+
+	@Test
+	public void customMessageFormatter() throws Exception {
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.messageFormatter((messageKey, defaultMessageFormat, args,
+						locale) -> args[0].toString().toUpperCase() + "."
+								+ messageKey.toUpperCase())
+				.constraint(User::getAge, "age", c -> c.notNull() //
+						.greaterThanOrEqual(0) //
+						.lessThanOrEqual(20))
+				.build();
+		User user = new User("foo", "foo@example.com", 30);
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo("AGE.NUMERIC.LESSTHANOREQUAL");
+		assertThat(violations.get(0).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+	}
+
+	@Test
+	public void details() throws Exception {
+		User user = new User("", "example.com", 300);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		List<ViolationDetail> details = violations.details();
+		assertThat(details.size()).isEqualTo(3);
+		assertThat(details.get(0).getDefaultMessage()).isEqualTo(
+				"The size of \"name\" must be greater than or equal to 1. The given size is 0");
+		assertThat(details.get(0).getKey()).isEqualTo("container.greaterThanOrEqual");
+		assertThat(details.get(0).getArgs()).containsExactly("name", 1, 0);
+		assertThat(details.get(1).getDefaultMessage())
+				.isEqualTo("\"email\" must be a valid email address");
+		assertThat(details.get(1).getKey()).isEqualTo("charSequence.email");
+		assertThat(details.get(1).getArgs()).containsExactly("email", "example.com");
+		assertThat(details.get(2).getDefaultMessage())
+				.isEqualTo("\"age\" must be less than or equal to 200");
+		assertThat(details.get(2).getKey()).isEqualTo("numeric.lessThanOrEqual");
+		assertThat(details.get(2).getArgs()).containsExactly("age", 200, 300);
+	}
+
+	@Test
+	public void emojiInValid() throws Exception {
+		User user = new User("I❤️☕️", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name", c -> c.emoji().greaterThan(3)).build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"name\" must be greater than 3. The given size is 3");
+	}
+
+	@Test
+	public void emojiValid() throws Exception {
+		User user = new User("I❤️☕️", null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name", c -> c.emoji().lessThanOrEqual(3))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void group() {
+		User user = new User("foobar", "foo@example.com", -1);
+		Validator<User> validator = ValidatorBuilder.of(User.class) //
+				.constraintOnCondition(Group.UPDATE.toCondition(), //
+						b -> b.constraint(User::getName, "name",
+								c -> c.lessThanOrEqual(5)))
+				.build();
+		{
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isTrue();
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"name\" must be less than or equal to 5. The given size is 6");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+	}
+
+	@Test
+	public void groupConditionByGroup() {
+		User user = new User("foobar", "foo@example.com", -1);
+		Validator<User> validator = ValidatorBuilder.of(User.class) //
+				.constraintOnCondition(
+						(u, cg) -> cg == Group.UPDATE || cg == Group.DELETE, //
+						b -> b.constraint(User::getName, "name",
+								c -> c.lessThanOrEqual(5)))
+				.build();
+		{
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isTrue();
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"name\" must be less than or equal to 5. The given size is 6");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.DELETE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"name\" must be less than or equal to 5. The given size is 6");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+	}
+
+	@Test
+	public void groupTwoCondition() {
+		User user = new User("foobar", "foo@example.com", -1);
+		Validator<User> validator = ValidatorBuilder.of(User.class) //
+				.constraintOnGroup(Group.UPDATE, //
+						b -> b.constraint(User::getName, "name",
+								c -> c.lessThanOrEqual(5)))
+				.constraintOnGroup(Group.DELETE, //
+						b -> b.constraint(User::getName, "name",
+								c -> c.greaterThanOrEqual(5)))
+				.build();
+		{
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isTrue();
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"name\" must be less than or equal to 5. The given size is 6");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.DELETE);
+			assertThat(violations.isValid()).isTrue();
+		}
+	}
+
+	@Test
+	public void ivsByteSizeInValid() throws Exception {
+		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.variant(opts -> opts.ivs(IGNORE)).lessThanOrEqual(3)
+								.asByteArray().lessThanOrEqual(12))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The byte size of \"name\" must be less than or equal to 12. The given size is 13");
+	}
+
+	@Test
+	public void ivsInValid() throws Exception {
+		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.fixedSize(3).asByteArray().fixedSize(13))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("The size of \"name\" must be 3. The given size is 4");
+	}
+
+	@Test
+	public void ivsSizeAndByteSizeInValid() throws Exception {
+		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.lessThanOrEqual(3).asByteArray().lessThanOrEqual(12))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(2);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"name\" must be less than or equal to 3. The given size is 4");
+		assertThat(violations.get(1).message()).isEqualTo(
+				"The byte size of \"name\" must be less than or equal to 12. The given size is 13");
+	}
+
+	@Test
+	public void ivsValid() throws Exception {
+		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+		Validator<User> validator = ValidatorBuilder.of(User.class)
+				.constraint(User::getName, "name",
+						c -> c.variant(opts -> opts.ivs(IGNORE)).fixedSize(3)
+								.asByteArray().fixedSize(13))
+				.build();
+		ConstraintViolations violations = validator.validate(user);
+		violations.forEach(x -> System.out.println(x.message()));
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void multipleViolationOnOneProperty() throws Exception {
+		User user = new User("foo", "aa", 200);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(2);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"email\" must be greater than or equal to 5. The given size is 2");
+		assertThat(violations.get(0).messageKey())
+				.isEqualTo("container.greaterThanOrEqual");
+		assertThat(violations.get(1).message())
+				.isEqualTo("\"email\" must be a valid email address");
+		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+	}
+
+	@Test
+	public void nullValues() throws Exception {
+		User user = new User(null, null, null);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(3);
+		assertThat(violations.get(0).message()).isEqualTo("\"name\" must not be null");
+		assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
+		assertThat(violations.get(1).message()).isEqualTo("\"email\" must not be null");
+		assertThat(violations.get(1).messageKey()).isEqualTo("object.notNull");
+		assertThat(violations.get(2).message()).isEqualTo("\"age\" must not be null");
+		assertThat(violations.get(2).messageKey()).isEqualTo("object.notNull");
+	}
+
+	@Test
+	public void overrideMessage() {
+		Validator<User> validator = ValidatorBuilder.<User> of() //
+				.constraint(User::getName, "name",
+						c -> c.notNull().message("name is required!") //
+								.greaterThanOrEqual(1).message("name is too small!") //
+								.lessThanOrEqual(20).message("name is too large!")) //
+				.build();
+		{
+			User user = new User(null, "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is required!");
+			assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
+		}
+		{
+			User user = new User("", "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is too small!");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.greaterThanOrEqual");
+		}
+		{
+			User user = new User("012345678901234567890", "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is too large!");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+	}
+
+	@Test
+	public void overrideViolationMessage() {
+		Validator<User> validator = ValidatorBuilder.<User> of() //
+				.constraint(User::getName, "name",
+						c -> c.notNull()
+								.message(ViolationMessage.of("a", "name is required!")) //
+								.greaterThanOrEqual(1)
+								.message(ViolationMessage.of("b", "name is too small!")) //
+								.lessThanOrEqual(20)
+								.message(ViolationMessage.of("c", "name is too large!"))) //
+				.build();
+		{
+			User user = new User(null, "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is required!");
+			assertThat(violations.get(0).messageKey()).isEqualTo("a");
+		}
+		{
+			User user = new User("", "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is too small!");
+			assertThat(violations.get(0).messageKey()).isEqualTo("b");
+		}
+		{
+			User user = new User("012345678901234567890", "a@b.c", 10);
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo("name is too large!");
+			assertThat(violations.get(0).messageKey()).isEqualTo("c");
+		}
+	}
+
+	@Test
+	public void throwIfInValidInValid() throws Exception {
+		User user = new User("foo", "foo@example.com", -1);
+		try {
+			validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
+			fail("fail");
+		}
+		catch (ConstraintViolationsException e) {
+			ConstraintViolations violations = e.getViolations();
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message())
+					.isEqualTo("\"age\" must be greater than or equal to 0");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("numeric.greaterThanOrEqual");
+		}
+	}
+
+	@Test
+	public void throwIfInValidValid() throws Exception {
+		User user = new User("foo", "foo@example.com", 30);
+		validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
+	}
+
+	@Test
+	public void valid() throws Exception {
+		User user = new User("foo", "foo@example.com", 30);
+		Validator<User> validator = validator();
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void validateToEitherInValid() throws Exception {
+		User user = new User("foo", "foo@example.com", -1);
+		Either<ConstraintViolations, User> either = validator().validateToEither(user);
+		assertThat(either.isLeft()).isTrue();
+		ConstraintViolations violations = either.left().get();
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.isEqualTo("\"age\" must be greater than or equal to 0");
+		assertThat(violations.get(0).messageKey())
+				.isEqualTo("numeric.greaterThanOrEqual");
+	}
+
+	@Test
+	public void validateToEitherValid() throws Exception {
+		User user = new User("foo", "foo@example.com", 30);
+		Either<ConstraintViolations, User> either = validator().validateToEither(user);
+		assertThat(either.isRight()).isTrue();
+		assertThat(either.right().get()).isSameAs(user);
+	}
+
+	@Test
+	public void violateGroupAndDefault() {
+		User user = new User("foobar", "foo@example.com", -1);
+		Validator<User> validator = ValidatorBuilder.of(User.class) //
+				.constraint(User::getEmail, "email", c -> c.email().lessThanOrEqual(10))
+				.constraintOnGroup(Group.UPDATE, //
+						b -> b.constraint(User::getName, "name",
+								c -> c.lessThanOrEqual(5)))
+				.build();
+		{
+			ConstraintViolations violations = validator.validate(user);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(1);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"email\" must be less than or equal to 10. The given size is 15");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+		{
+			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+			assertThat(violations.isValid()).isFalse();
+			assertThat(violations.size()).isEqualTo(2);
+			assertThat(violations.get(0).message()).isEqualTo(
+					"The size of \"email\" must be less than or equal to 10. The given size is 15");
+			assertThat(violations.get(0).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+			assertThat(violations.get(1).message()).isEqualTo(
+					"The size of \"name\" must be less than or equal to 5. The given size is 6");
+			assertThat(violations.get(1).messageKey())
+					.isEqualTo("container.lessThanOrEqual");
+		}
+	}
 }

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -15,17 +15,6 @@
  */
 package am.ik.yavi.core;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.junit.Test;
-
-import static am.ik.yavi.constraint.charsequence.variant.IdeographicVariationSequence.IGNORE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import am.ik.yavi.ConstraintViolationsException;
 import am.ik.yavi.Range;
 import am.ik.yavi.User;
@@ -34,679 +23,768 @@ import am.ik.yavi.constraint.charsequence.CodePoints;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsRanges;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
 import am.ik.yavi.fn.Either;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static am.ik.yavi.constraint.charsequence.variant.IdeographicVariationSequence.IGNORE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ValidatorTest {
-	@Test
-	public void allInvalid() throws Exception {
-		User user = new User("", "example.com", 300);
-		user.setEnabled(false);
-		Validator<User> validator = validator();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(4);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The size of \"name\" must be greater than or equal to 1. The given size is 0");
-		assertThat(violations.get(0).messageKey())
-				.isEqualTo("container.greaterThanOrEqual");
-		assertThat(violations.get(1).message())
-				.isEqualTo("\"email\" must be a valid email address");
-		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
-		assertThat(violations.get(2).message())
-				.isEqualTo("\"age\" must be less than or equal to 200");
-		assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
-		assertThat(violations.get(3).message()).isEqualTo("\"enabled\" must be true");
-		assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
-	}
 
-	@Test
-	public void codePointsAllIncludedRange() throws Exception {
-		CodePointsRanges<String> whiteList = () -> Arrays.asList(
-				CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
-				CodePoints.Range.of(0x0061/* a */, 0x007A /* z */));
+    public static final IncludedViolationMessages germanViolationMessages = new IncludedViolationMessages() {
+        @Override
+        public ViolationMessage OBJECT_NOT_NULL() {
+            return ViolationMessage.of("notnulll", "Für \"{0}\" muss ein Wert vorhanden sein.");
+        }
 
-		User user = new User("abc@b.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(whiteList).asWhiteList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-	}
+        @Override
+        public ViolationMessage OBJECT_IS_NULL() {
+            return null;
+        }
 
-	@Test
-	public void codePointsAllIncludedRangeBeginToEnd() throws Exception {
-		User user = new User("abc@b.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(0x0041/* A */, 0x007A /* z */).asWhiteList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-	}
+        @Override
+        public ViolationMessage CONTAINER_NOT_EMPTY() {
+            return null;
+        }
 
-	@Test
-	public void codePointsAllIncludedRangeRange() throws Exception {
-		User user = new User("abc@b.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class).constraint(
-				User::getName, "name",
-				c -> c.codePoints(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
-						CodePoints.Range.of(0x0061/* a */, 0x007A /* z */)).asWhiteList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-	}
+        @Override
+        public ViolationMessage CONTAINER_LESS_THAN() {
+            return null;
+        }
 
-	@Test
-	public void codePointsAllIncludedSet() throws Exception {
-		CodePointsSet<String> whiteList = () -> new HashSet<>(
-				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
-						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
-						0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
-						0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */,
-						0x0050 /* P */, 0x0051 /* Q */, 0x0052 /* R */, 0x0053 /* S */,
-						0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
-						0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
-						0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */,
-						0x0065 /* e */, 0x0066 /* f */, 0x0067 /* g */, 0x0068 /* h */,
-						0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
-						0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */,
-						0x0071 /* q */, 0x0072 /* r */, 0x0073 /* s */, 0x0074 /* t */,
-						0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
-						0x0079 /* y */, 0x007A /* z */));
+        @Override
+        public ViolationMessage CONTAINER_LESS_THAN_OR_EQUAL() {
+            return ViolationMessage.of("container.lessThanOrEqual",
+                    "Die Länge von \"{0}\" muss kleiner oder gleich {1} sein. Aktuelle Länge ist {2}.");
+        }
 
-		User user = new User("abc@b.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(whiteList).asWhiteList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-	}
+        @Override
+        public ViolationMessage CONTAINER_GREATER_THAN() {
+            return null;
+        }
 
-	@Test
-	public void codePointsAllIncludedSetSet() throws Exception {
-		Set<Integer> whiteList = new HashSet<>(
-				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
-						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
-						0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
-						0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */,
-						0x0050 /* P */, 0x0051 /* Q */, 0x0052 /* R */, 0x0053 /* S */,
-						0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
-						0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
-						0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */,
-						0x0065 /* e */, 0x0066 /* f */, 0x0067 /* g */, 0x0068 /* h */,
-						0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
-						0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */,
-						0x0071 /* q */, 0x0072 /* r */, 0x0073 /* s */, 0x0074 /* t */,
-						0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
-						0x0079 /* y */, 0x007A /* z */));
+        @Override
+        public ViolationMessage CONTAINER_GREATER_THAN_OR_EQUAL() {
+            return ViolationMessage.of("container.greaterThanOrEqual",
+                    "Die Länge von \"{0}\" muss größer oder gleich {1} sein. Aktuelle Länge ist {2}.");
+        }
 
-		User user = new User("abc@b.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(whiteList).asWhiteList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
-	}
+        @Override
+        public ViolationMessage CONTAINER_FIXED_SIZE() {
+            return null;
+        }
 
-	@Test
-	public void codePointsNotIncludedRange() throws Exception {
-		CodePointsRanges<String> blackList = () -> Arrays.asList(
-				CodePoints.Range.of(0x0041/* A */, 0x0042 /* B */),
-				CodePoints.Range.of(0x0061/* a */, 0x0062 /* b */));
+        @Override
+        public ViolationMessage NUMERIC_GREATER_THAN() {
+            return null;
+        }
 
-		User user = new User("abcA@Bb.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(blackList).asBlackList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[a, b, A, B]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
-	}
+        @Override
+        public ViolationMessage NUMERIC_GREATER_THAN_OR_EQUAL() {
+            return ViolationMessage.of("numeric.greaterThanOrEqual", "\"{0}\" muss größer gleich {1} sein.");
+        }
 
-	@Test
-	public void codePointsNotIncludedSet() throws Exception {
-		CodePointsSet<String> blackList = () -> new HashSet<>(
-				Arrays.asList(0x0061 /* a */, 0x0062 /* b */));
+        @Override
+        public ViolationMessage NUMERIC_LESS_THAN() {
+            return null;
+        }
 
-		User user = new User("abcA@Bb.c", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.codePoints(blackList).asBlackList())
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"[a, b]\" is/are not allowed for \"name\"");
-		assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
-	}
+        @Override
+        public ViolationMessage NUMERIC_LESS_THAN_OR_EQUAL() {
+            return ViolationMessage.of("numeric.lessThanOrEqual", "\"{0}\" muss kleiner gleich {1} sein.");
+        }
 
-	@Test
-	public void combiningCharacterByteSizeInValid() throws Exception {
-		User user = new User("モジ" /* モシ\u3099 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.lessThanOrEqual(2).asByteArray().lessThanOrEqual(6))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The byte size of \"name\" must be less than or equal to 6. The given size is 9");
-	}
+        @Override
+        public ViolationMessage BOOLEAN_IS_TRUE() {
+            return ViolationMessage.of("boolean.isTrue", "\"{0}\" muss wahr sein.");
+        }
 
-	@Test
-	public void combiningCharacterSizeAndByteSizeInValid() throws Exception {
-		User user = new User("モジ" /* モシ\u3099 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.lessThanOrEqual(1).asByteArray().lessThanOrEqual(3))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(2);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The size of \"name\" must be less than or equal to 1. The given size is 2");
-		assertThat(violations.get(1).message()).isEqualTo(
-				"The byte size of \"name\" must be less than or equal to 3. The given size is 9");
-	}
+        @Override
+        public ViolationMessage BOOLEAN_IS_FALSE() {
+            return null;
+        }
 
-	@Test
-	public void combiningCharacterValid() throws Exception {
-		User user = new User("モジ" /* モシ\u3099 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.fixedSize(2).asByteArray().fixedSize(9))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isTrue();
-	}
+        @Override
+        public ViolationMessage CHAR_SEQUENCE_NOT_BLANK() {
+            return null;
+        }
 
-	@Test
-	public void condition() {
-		Validator<User> validator = ValidatorBuilder.of(User.class) //
-				.constraintOnCondition((u, cg) -> !u.getName().isEmpty(), //
-						b -> b.constraint(User::getEmail, "email",
-								c -> c.email().notEmpty()))
-				.build();
-		{
-			User user = new User("", "", -1);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isTrue();
-		}
-		{
-			User user = new User("foobar", "", -1);
-			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message())
-					.isEqualTo("\"email\" must not be empty");
-			assertThat(violations.get(0).messageKey()).isEqualTo("container.notEmpty");
-		}
-	}
+        @Override
+        public ViolationMessage CHAR_SEQUENCE_CONTAINS() {
+            return null;
+        }
 
-	@Test
-	public void constraintOnTarget() {
-		Validator<Range> validator = ValidatorBuilder.of(Range.class) //
-				.constraintOnTarget(Range::isToGreaterThanFrom, "to",
-						"to.isGreaterThanFrom", "\"to\" must be greater than \"from\".") //
-				.build();
-		{
-			Range range = new Range(1, 10);
-			ConstraintViolations violations = validator.validate(range);
-			assertThat(violations.isValid()).isTrue();
-		}
-		{
-			Range range = new Range(10, 1);
-			ConstraintViolations violations = validator.validate(range);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message())
-					.isEqualTo("\"to\" must be greater than \"from\".");
-			assertThat(violations.get(0).messageKey()).isEqualTo("to.isGreaterThanFrom");
-		}
-	}
+        @Override
+        public ViolationMessage CHAR_SEQUENCE_EMAIL() {
+            return ViolationMessage.of("charSequence.email", "\"{0}\" muss eine gültige E-Mail Adresse sein.");
+        }
 
-	@Test
-	public void customMessageFormatter() throws Exception {
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.messageFormatter((messageKey, defaultMessageFormat, args,
-						locale) -> args[0].toString().toUpperCase() + "."
-								+ messageKey.toUpperCase())
-				.constraint(User::getAge, "age", c -> c.notNull() //
-						.greaterThanOrEqual(0) //
-						.lessThanOrEqual(20))
-				.build();
-		User user = new User("foo", "foo@example.com", 30);
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message()).isEqualTo("AGE.NUMERIC.LESSTHANOREQUAL");
-		assertThat(violations.get(0).messageKey()).isEqualTo("numeric.lessThanOrEqual");
-	}
+        @Override
+        public ViolationMessage CHAR_SEQUENCE_URL() {
+            return null;
+        }
 
-	@Test
-	public void details() throws Exception {
-		User user = new User("", "example.com", 300);
-		Validator<User> validator = validator();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		List<ViolationDetail> details = violations.details();
-		assertThat(details.size()).isEqualTo(3);
-		assertThat(details.get(0).getDefaultMessage()).isEqualTo(
-				"The size of \"name\" must be greater than or equal to 1. The given size is 0");
-		assertThat(details.get(0).getKey()).isEqualTo("container.greaterThanOrEqual");
-		assertThat(details.get(0).getArgs()).containsExactly("name", 1, 0);
-		assertThat(details.get(1).getDefaultMessage())
-				.isEqualTo("\"email\" must be a valid email address");
-		assertThat(details.get(1).getKey()).isEqualTo("charSequence.email");
-		assertThat(details.get(1).getArgs()).containsExactly("email", "example.com");
-		assertThat(details.get(2).getDefaultMessage())
-				.isEqualTo("\"age\" must be less than or equal to 200");
-		assertThat(details.get(2).getKey()).isEqualTo("numeric.lessThanOrEqual");
-		assertThat(details.get(2).getArgs()).containsExactly("age", 200, 300);
-	}
+        @Override
+        public ViolationMessage CHAR_SEQUENCE_PATTERN() {
+            return null;
+        }
 
-	@Test
-	public void emojiInValid() throws Exception {
-		User user = new User("I❤️☕️", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name", c -> c.emoji().greaterThan(3)).build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The size of \"name\" must be greater than 3. The given size is 3");
-	}
+        @Override
+        public ViolationMessage BYTE_SIZE_LESS_THAN() {
+            return null;
+        }
 
-	@Test
-	public void emojiValid() throws Exception {
-		User user = new User("I❤️☕️", null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name", c -> c.emoji().lessThanOrEqual(3))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isTrue();
-	}
+        @Override
+        public ViolationMessage BYTE_SIZE_LESS_THAN_OR_EQUAL() {
+            return null;
+        }
 
-	@Test
-	public void group() {
-		User user = new User("foobar", "foo@example.com", -1);
-		Validator<User> validator = ValidatorBuilder.of(User.class) //
-				.constraintOnCondition(Group.UPDATE.toCondition(), //
-						b -> b.constraint(User::getName, "name",
-								c -> c.lessThanOrEqual(5)))
-				.build();
-		{
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isTrue();
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"name\" must be less than or equal to 5. The given size is 6");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-	}
+        @Override
+        public ViolationMessage BYTE_SIZE_GREATER_THAN() {
+            return null;
+        }
 
-	@Test
-	public void groupConditionByGroup() {
-		User user = new User("foobar", "foo@example.com", -1);
-		Validator<User> validator = ValidatorBuilder.of(User.class) //
-				.constraintOnCondition(
-						(u, cg) -> cg == Group.UPDATE || cg == Group.DELETE, //
-						b -> b.constraint(User::getName, "name",
-								c -> c.lessThanOrEqual(5)))
-				.build();
-		{
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isTrue();
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"name\" must be less than or equal to 5. The given size is 6");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.DELETE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"name\" must be less than or equal to 5. The given size is 6");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-	}
+        @Override
+        public ViolationMessage BYTE_SIZE_GREATER_THAN_OR_EQUAL() {
+            return null;
+        }
 
-	@Test
-	public void groupTwoCondition() {
-		User user = new User("foobar", "foo@example.com", -1);
-		Validator<User> validator = ValidatorBuilder.of(User.class) //
-				.constraintOnGroup(Group.UPDATE, //
-						b -> b.constraint(User::getName, "name",
-								c -> c.lessThanOrEqual(5)))
-				.constraintOnGroup(Group.DELETE, //
-						b -> b.constraint(User::getName, "name",
-								c -> c.greaterThanOrEqual(5)))
-				.build();
-		{
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isTrue();
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"name\" must be less than or equal to 5. The given size is 6");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.DELETE);
-			assertThat(violations.isValid()).isTrue();
-		}
-	}
+        @Override
+        public ViolationMessage BYTE_SIZE_FIXED_SIZE() {
+            return null;
+        }
 
-	@Test
-	public void ivsByteSizeInValid() throws Exception {
-		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.variant(opts -> opts.ivs(IGNORE)).lessThanOrEqual(3)
-								.asByteArray().lessThanOrEqual(12))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The byte size of \"name\" must be less than or equal to 12. The given size is 13");
-	}
+        @Override
+        public ViolationMessage COLLECTION_CONTAINS() {
+            return null;
+        }
 
-	@Test
-	public void ivsInValid() throws Exception {
-		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.fixedSize(3).asByteArray().fixedSize(13))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("The size of \"name\" must be 3. The given size is 4");
-	}
+        @Override
+        public ViolationMessage MAP_CONTAINS_VALUE() {
+            return null;
+        }
 
-	@Test
-	public void ivsSizeAndByteSizeInValid() throws Exception {
-		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.lessThanOrEqual(3).asByteArray().lessThanOrEqual(12))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(2);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The size of \"name\" must be less than or equal to 3. The given size is 4");
-		assertThat(violations.get(1).message()).isEqualTo(
-				"The byte size of \"name\" must be less than or equal to 12. The given size is 13");
-	}
+        @Override
+        public ViolationMessage MAP_CONTAINS_KEY() {
+            return null;
+        }
 
-	@Test
-	public void ivsValid() throws Exception {
-		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
-		Validator<User> validator = ValidatorBuilder.of(User.class)
-				.constraint(User::getName, "name",
-						c -> c.variant(opts -> opts.ivs(IGNORE)).fixedSize(3)
-								.asByteArray().fixedSize(13))
-				.build();
-		ConstraintViolations violations = validator.validate(user);
-		violations.forEach(x -> System.out.println(x.message()));
-		assertThat(violations.isValid()).isTrue();
-	}
+        @Override
+        public ViolationMessage ARRAY_CONTAINS() {
+            return null;
+        }
 
-	@Test
-	public void multipleViolationOnOneProperty() throws Exception {
-		User user = new User("foo", "aa", 200);
-		Validator<User> validator = validator();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(2);
-		assertThat(violations.get(0).message()).isEqualTo(
-				"The size of \"email\" must be greater than or equal to 5. The given size is 2");
-		assertThat(violations.get(0).messageKey())
-				.isEqualTo("container.greaterThanOrEqual");
-		assertThat(violations.get(1).message())
-				.isEqualTo("\"email\" must be a valid email address");
-		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
-	}
+        @Override
+        public ViolationMessage CODE_POINTS_ALL_INCLUDED() {
+            return null;
+        }
 
-	@Test
-	public void nullValues() throws Exception {
-		User user = new User(null, null, null);
-		Validator<User> validator = validator();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(3);
-		assertThat(violations.get(0).message()).isEqualTo("\"name\" must not be null");
-		assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
-		assertThat(violations.get(1).message()).isEqualTo("\"email\" must not be null");
-		assertThat(violations.get(1).messageKey()).isEqualTo("object.notNull");
-		assertThat(violations.get(2).message()).isEqualTo("\"age\" must not be null");
-		assertThat(violations.get(2).messageKey()).isEqualTo("object.notNull");
-	}
+        @Override
+        public ViolationMessage CODE_POINTS_NOT_INCLUDED() {
+            return null;
+        }
+    };
 
-	@Test
-	public void overrideMessage() {
-		Validator<User> validator = ValidatorBuilder.<User> of() //
-				.constraint(User::getName, "name",
-						c -> c.notNull().message("name is required!") //
-								.greaterThanOrEqual(1).message("name is too small!") //
-								.lessThanOrEqual(20).message("name is too large!")) //
-				.build();
+    @Test
+    public void allInvalid() throws Exception {
+        User user = new User("", "example.com", 300);
+        user.setEnabled(false);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(4);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The size of \"name\" must be greater than or equal to 1. The given size is 0");
+        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
+        assertThat(violations.get(1).message()).isEqualTo("\"email\" must be a valid email address");
+        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+        assertThat(violations.get(2).message()).isEqualTo("\"age\" must be less than or equal to 200");
+        assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+        assertThat(violations.get(3).message()).isEqualTo("\"enabled\" must be true");
+        assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
+    }
 
-		{
-			User user = new User(null, "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is required!");
-			assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
-		}
-		{
-			User user = new User("", "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is too small!");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.greaterThanOrEqual");
-		}
-		{
-			User user = new User("012345678901234567890", "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is too large!");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-	}
+    Validator<User> validator() {
+        return ValidatorBuilder.<User>of() //
+                .constraint(User::getName, "name", c -> c.notNull() //
+                        .greaterThanOrEqual(1) //
+                        .lessThanOrEqual(20)) //
+                .constraint(User::getEmail, "email", c -> c.notNull() //
+                        .greaterThanOrEqual(5) //
+                        .lessThanOrEqual(50) //
+                        .email()) //
+                .constraint(User::getAge, "age", c -> c.notNull() //
+                        .greaterThanOrEqual(0) //
+                        .lessThanOrEqual(200)) //
+                .constraint(User::isEnabled, "enabled", c -> c.isTrue()) //
+                .build();
+    }
 
-	@Test
-	public void overrideViolationMessage() {
-		Validator<User> validator = ValidatorBuilder.<User> of() //
-				.constraint(User::getName, "name",
-						c -> c.notNull()
-								.message(ViolationMessage.of("a", "name is required!")) //
-								.greaterThanOrEqual(1)
-								.message(ViolationMessage.of("b", "name is too small!")) //
-								.lessThanOrEqual(20)
-								.message(ViolationMessage.of("c", "name is too large!"))) //
-				.build();
+    @Test
+    public void allInvalidCustomIncludedViolationMessages() throws Exception {
+        IncludedViolationMessages.define(germanViolationMessages);
+        User user = new User("", "example.com", 300);
+        user.setEnabled(false);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(4);
+        assertThat(violations.get(0).message())
+                .isEqualTo("Die Länge von \"name\" muss größer oder gleich 1 sein. Aktuelle Länge ist 0.");
+        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
+        assertThat(violations.get(1).message()).isEqualTo("\"email\" muss eine gültige E-Mail Adresse sein.");
+        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+        assertThat(violations.get(2).message()).isEqualTo("\"age\" muss kleiner gleich 200 sein.");
+        assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+        assertThat(violations.get(3).message()).isEqualTo("\"enabled\" muss wahr sein.");
+        assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
+        IncludedViolationMessages.define(new DefaultIncludedViolationMessages());
+    }
 
-		{
-			User user = new User(null, "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is required!");
-			assertThat(violations.get(0).messageKey()).isEqualTo("a");
-		}
-		{
-			User user = new User("", "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is too small!");
-			assertThat(violations.get(0).messageKey()).isEqualTo("b");
-		}
-		{
-			User user = new User("012345678901234567890", "a@b.c", 10);
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo("name is too large!");
-			assertThat(violations.get(0).messageKey()).isEqualTo("c");
-		}
-	}
+    @Test
+    public void codePointsAllIncludedRange() throws Exception {
+        CodePointsRanges<String> whiteList = () -> Arrays.asList(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
+                CodePoints.Range.of(0x0061/* a */, 0x007A /* z */));
+        User user = new User("abc@b.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+    }
 
-	@Test
-	public void throwIfInValidInValid() throws Exception {
-		User user = new User("foo", "foo@example.com", -1);
-		try {
-			validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
-			fail("fail");
-		}
-		catch (ConstraintViolationsException e) {
-			ConstraintViolations violations = e.getViolations();
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message())
-					.isEqualTo("\"age\" must be greater than or equal to 0");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("numeric.greaterThanOrEqual");
-		}
-	}
+    @Test
+    public void codePointsAllIncludedRangeBeginToEnd() throws Exception {
+        User user = new User("abc@b.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(0x0041/* A */, 0x007A /* z */).asWhiteList())
+                .build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+    }
 
-	@Test
-	public void throwIfInValidValid() throws Exception {
-		User user = new User("foo", "foo@example.com", 30);
-		validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
-	}
+    @Test
+    public void codePointsAllIncludedRangeRange() throws Exception {
+        User user = new User("abc@b.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
+                c -> c.codePoints(CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
+                        CodePoints.Range.of(0x0061/* a */, 0x007A /* z */)).asWhiteList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+    }
 
-	@Test
-	public void valid() throws Exception {
-		User user = new User("foo", "foo@example.com", 30);
-		Validator<User> validator = validator();
-		ConstraintViolations violations = validator.validate(user);
-		assertThat(violations.isValid()).isTrue();
-	}
+    @Test
+    public void codePointsAllIncludedSet() throws Exception {
+        CodePointsSet<String> whiteList = () -> new HashSet<>(
+                Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */, 0x0044 /* D */, 0x0045 /* E */,
+                        0x0046 /* F */, 0x0047 /* G */, 0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
+                        0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */, 0x0050 /* P */, 0x0051 /* Q */,
+                        0x0052 /* R */, 0x0053 /* S */, 0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
+                        0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
+                        0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */, 0x0065 /* e */, 0x0066 /* f */,
+                        0x0067 /* g */, 0x0068 /* h */, 0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
+                        0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */, 0x0071 /* q */, 0x0072 /* r */,
+                        0x0073 /* s */, 0x0074 /* t */, 0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
+                        0x0079 /* y */, 0x007A /* z */));
+        User user = new User("abc@b.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+    }
 
-	@Test
-	public void validateToEitherInValid() throws Exception {
-		User user = new User("foo", "foo@example.com", -1);
-		Either<ConstraintViolations, User> either = validator().validateToEither(user);
-		assertThat(either.isLeft()).isTrue();
-		ConstraintViolations violations = either.left().get();
-		assertThat(violations.isValid()).isFalse();
-		assertThat(violations.size()).isEqualTo(1);
-		assertThat(violations.get(0).message())
-				.isEqualTo("\"age\" must be greater than or equal to 0");
-		assertThat(violations.get(0).messageKey())
-				.isEqualTo("numeric.greaterThanOrEqual");
-	}
+    @Test
+    public void codePointsAllIncludedSetSet() throws Exception {
+        Set<Integer> whiteList = new HashSet<>(
+                Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */, 0x0044 /* D */, 0x0045 /* E */,
+                        0x0046 /* F */, 0x0047 /* G */, 0x0048 /* H */, 0x0049 /* I */, 0x004A /* J */, 0x004B /* K */,
+                        0x004C /* L */, 0x004D /* M */, 0x004E /* N */, 0x004F /* O */, 0x0050 /* P */, 0x0051 /* Q */,
+                        0x0052 /* R */, 0x0053 /* S */, 0x0054 /* T */, 0x0055 /* U */, 0x0056 /* V */, 0x0057 /* W */,
+                        0x0058 /* X */, 0x0059 /* Y */, 0x005A /* Z */, //
+                        0x0061 /* a */, 0x0062 /* b */, 0x0063 /* c */, 0x0064 /* d */, 0x0065 /* e */, 0x0066 /* f */,
+                        0x0067 /* g */, 0x0068 /* h */, 0x0069 /* i */, 0x006A /* j */, 0x006B /* k */, 0x006C /* l */,
+                        0x006D /* m */, 0x006E /* n */, 0x006F /* o */, 0x0070 /* p */, 0x0071 /* q */, 0x0072 /* r */,
+                        0x0073 /* s */, 0x0074 /* t */, 0x0075 /* u */, 0x0076 /* v */, 0x0077 /* w */, 0x0078 /* x */,
+                        0x0079 /* y */, 0x007A /* z */));
+        User user = new User("abc@b.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(whiteList).asWhiteList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[@, .]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asWhiteList");
+    }
 
-	@Test
-	public void validateToEitherValid() throws Exception {
-		User user = new User("foo", "foo@example.com", 30);
-		Either<ConstraintViolations, User> either = validator().validateToEither(user);
-		assertThat(either.isRight()).isTrue();
-		assertThat(either.right().get()).isSameAs(user);
-	}
+    @Test
+    public void codePointsNotIncludedRange() throws Exception {
+        CodePointsRanges<String> blackList = () -> Arrays.asList(CodePoints.Range.of(0x0041/* A */, 0x0042 /* B */),
+                CodePoints.Range.of(0x0061/* a */, 0x0062 /* b */));
+        User user = new User("abcA@Bb.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(blackList).asBlackList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[a, b, A, B]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
+    }
 
-	@Test
-	public void violateGroupAndDefault() {
-		User user = new User("foobar", "foo@example.com", -1);
-		Validator<User> validator = ValidatorBuilder.of(User.class) //
-				.constraint(User::getEmail, "email", c -> c.email().lessThanOrEqual(10))
-				.constraintOnGroup(Group.UPDATE, //
-						b -> b.constraint(User::getName, "name",
-								c -> c.lessThanOrEqual(5)))
-				.build();
-		{
-			ConstraintViolations violations = validator.validate(user);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(1);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"email\" must be less than or equal to 10. The given size is 15");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-		{
-			ConstraintViolations violations = validator.validate(user, Group.UPDATE);
-			assertThat(violations.isValid()).isFalse();
-			assertThat(violations.size()).isEqualTo(2);
-			assertThat(violations.get(0).message()).isEqualTo(
-					"The size of \"email\" must be less than or equal to 10. The given size is 15");
-			assertThat(violations.get(0).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-			assertThat(violations.get(1).message()).isEqualTo(
-					"The size of \"name\" must be less than or equal to 5. The given size is 6");
-			assertThat(violations.get(1).messageKey())
-					.isEqualTo("container.lessThanOrEqual");
-		}
-	}
+    @Test
+    public void codePointsNotIncludedSet() throws Exception {
+        CodePointsSet<String> blackList = () -> new HashSet<>(Arrays.asList(0x0061 /* a */, 0x0062 /* b */));
+        User user = new User("abcA@Bb.c", null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.codePoints(blackList).asBlackList()).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"[a, b]\" is/are not allowed for \"name\"");
+        assertThat(violations.get(0).messageKey()).isEqualTo("codePoints.asBlackList");
+    }
 
-	Validator<User> validator() {
-		return ValidatorBuilder.<User> of() //
-				.constraint(User::getName, "name", c -> c.notNull() //
-						.greaterThanOrEqual(1) //
-						.lessThanOrEqual(20)) //
-				.constraint(User::getEmail, "email", c -> c.notNull() //
-						.greaterThanOrEqual(5) //
-						.lessThanOrEqual(50) //
-						.email()) //
-				.constraint(User::getAge, "age", c -> c.notNull() //
-						.greaterThanOrEqual(0) //
-						.lessThanOrEqual(200)) //
-				.constraint(User::isEnabled, "enabled", c -> c.isTrue()) //
-				.build();
-	}
+    @Test
+    public void combiningCharacterByteSizeInValid() throws Exception {
+        User user = new User("モジ" /* モシ\u3099 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.lessThanOrEqual(2).asByteArray().lessThanOrEqual(6)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The byte size of \"name\" must be less than or equal to 6. The given size is 9");
+    }
 
+    @Test
+    public void combiningCharacterSizeAndByteSizeInValid() throws Exception {
+        User user = new User("モジ" /* モシ\u3099 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.lessThanOrEqual(1).asByteArray().lessThanOrEqual(3)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(2);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The size of \"name\" must be less than or equal to 1. The given size is 2");
+        assertThat(violations.get(1).message())
+                .isEqualTo("The byte size of \"name\" must be less than or equal to 3. The given size is 9");
+    }
+
+    @Test
+    public void combiningCharacterValid() throws Exception {
+        User user = new User("モジ" /* モシ\u3099 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.fixedSize(2).asByteArray().fixedSize(9)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isTrue();
+    }
+
+    @Test
+    public void condition() {
+        Validator<User> validator = ValidatorBuilder.of(User.class) //
+                .constraintOnCondition((u, cg) -> !u.getName().isEmpty(), //
+                        b -> b.constraint(User::getEmail, "email", c -> c.email().notEmpty())).build();
+        {
+            User user = new User("", "", -1);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isTrue();
+        }
+        {
+            User user = new User("foobar", "", -1);
+            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("\"email\" must not be empty");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.notEmpty");
+        }
+    }
+
+    @Test
+    public void constraintOnTarget() {
+        Validator<Range> validator = ValidatorBuilder.of(Range.class) //
+                .constraintOnTarget(Range::isToGreaterThanFrom, "to", "to.isGreaterThanFrom",
+                        "\"to\" must be greater than \"from\".") //
+                .build();
+        {
+            Range range = new Range(1, 10);
+            ConstraintViolations violations = validator.validate(range);
+            assertThat(violations.isValid()).isTrue();
+        }
+        {
+            Range range = new Range(10, 1);
+            ConstraintViolations violations = validator.validate(range);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("\"to\" must be greater than \"from\".");
+            assertThat(violations.get(0).messageKey()).isEqualTo("to.isGreaterThanFrom");
+        }
+    }
+
+    @Test
+    public void customMessageFormatter() throws Exception {
+        Validator<User> validator = ValidatorBuilder.of(User.class).messageFormatter(
+                (messageKey, defaultMessageFormat, args, locale) -> args[0].toString().toUpperCase() + "." +
+                        messageKey.toUpperCase()).constraint(User::getAge, "age", c -> c.notNull() //
+                .greaterThanOrEqual(0) //
+                .lessThanOrEqual(20)).build();
+        User user = new User("foo", "foo@example.com", 30);
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("AGE.NUMERIC.LESSTHANOREQUAL");
+        assertThat(violations.get(0).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+    }
+
+    @Test
+    public void details() throws Exception {
+        User user = new User("", "example.com", 300);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        List<ViolationDetail> details = violations.details();
+        assertThat(details.size()).isEqualTo(3);
+        assertThat(details.get(0).getDefaultMessage())
+                .isEqualTo("The size of \"name\" must be greater than or equal to 1. The given size is 0");
+        assertThat(details.get(0).getKey()).isEqualTo("container.greaterThanOrEqual");
+        assertThat(details.get(0).getArgs()).containsExactly("name", 1, 0);
+        assertThat(details.get(1).getDefaultMessage()).isEqualTo("\"email\" must be a valid email address");
+        assertThat(details.get(1).getKey()).isEqualTo("charSequence.email");
+        assertThat(details.get(1).getArgs()).containsExactly("email", "example.com");
+        assertThat(details.get(2).getDefaultMessage()).isEqualTo("\"age\" must be less than or equal to 200");
+        assertThat(details.get(2).getKey()).isEqualTo("numeric.lessThanOrEqual");
+        assertThat(details.get(2).getArgs()).containsExactly("age", 200, 300);
+    }
+
+    @Test
+    public void emojiInValid() throws Exception {
+        User user = new User("I❤️☕️", null, null);
+        Validator<User> validator =
+                ValidatorBuilder.of(User.class).constraint(User::getName, "name", c -> c.emoji().greaterThan(3))
+                        .build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The size of \"name\" must be greater than 3. The given size is 3");
+    }
+
+    @Test
+    public void emojiValid() throws Exception {
+        User user = new User("I❤️☕️", null, null);
+        Validator<User> validator =
+                ValidatorBuilder.of(User.class).constraint(User::getName, "name", c -> c.emoji().lessThanOrEqual(3))
+                        .build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isTrue();
+    }
+
+    @Test
+    public void group() {
+        User user = new User("foobar", "foo@example.com", -1);
+        Validator<User> validator = ValidatorBuilder.of(User.class) //
+                .constraintOnCondition(Group.UPDATE.toCondition(), //
+                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
+        {
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isTrue();
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+    }
+
+    @Test
+    public void groupConditionByGroup() {
+        User user = new User("foobar", "foo@example.com", -1);
+        Validator<User> validator = ValidatorBuilder.of(User.class) //
+                .constraintOnCondition((u, cg) -> cg == Group.UPDATE || cg == Group.DELETE, //
+                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
+        {
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isTrue();
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.DELETE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+    }
+
+    @Test
+    public void groupTwoCondition() {
+        User user = new User("foobar", "foo@example.com", -1);
+        Validator<User> validator = ValidatorBuilder.of(User.class) //
+                .constraintOnGroup(Group.UPDATE, //
+                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5)))
+                .constraintOnGroup(Group.DELETE, //
+                        b -> b.constraint(User::getName, "name", c -> c.greaterThanOrEqual(5))).build();
+        {
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isTrue();
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.DELETE);
+            assertThat(violations.isValid()).isTrue();
+        }
+    }
+
+    @Test
+    public void ivsByteSizeInValid() throws Exception {
+        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
+                c -> c.variant(opts -> opts.ivs(IGNORE)).lessThanOrEqual(3).asByteArray().lessThanOrEqual(12)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The byte size of \"name\" must be less than or equal to 12. The given size is 13");
+    }
+
+    @Test
+    public void ivsInValid() throws Exception {
+        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.fixedSize(3).asByteArray().fixedSize(13)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("The size of \"name\" must be 3. The given size is 4");
+    }
+
+    @Test
+    public void ivsSizeAndByteSizeInValid() throws Exception {
+        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class)
+                .constraint(User::getName, "name", c -> c.lessThanOrEqual(3).asByteArray().lessThanOrEqual(12)).build();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(2);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The size of \"name\" must be less than or equal to 3. The given size is 4");
+        assertThat(violations.get(1).message())
+                .isEqualTo("The byte size of \"name\" must be less than or equal to 12. The given size is 13");
+    }
+
+    @Test
+    public void ivsValid() throws Exception {
+        User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
+        Validator<User> validator = ValidatorBuilder.of(User.class).constraint(User::getName, "name",
+                c -> c.variant(opts -> opts.ivs(IGNORE)).fixedSize(3).asByteArray().fixedSize(13)).build();
+        ConstraintViolations violations = validator.validate(user);
+        violations.forEach(x -> System.out.println(x.message()));
+        assertThat(violations.isValid()).isTrue();
+    }
+
+    @Test
+    public void multipleViolationOnOneProperty() throws Exception {
+        User user = new User("foo", "aa", 200);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(2);
+        assertThat(violations.get(0).message())
+                .isEqualTo("The size of \"email\" must be greater than or equal to 5. The given size is 2");
+        assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
+        assertThat(violations.get(1).message()).isEqualTo("\"email\" must be a valid email address");
+        assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+    }
+
+    @Test
+    public void nullValues() throws Exception {
+        User user = new User(null, null, null);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(3);
+        assertThat(violations.get(0).message()).isEqualTo("\"name\" must not be null");
+        assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
+        assertThat(violations.get(1).message()).isEqualTo("\"email\" must not be null");
+        assertThat(violations.get(1).messageKey()).isEqualTo("object.notNull");
+        assertThat(violations.get(2).message()).isEqualTo("\"age\" must not be null");
+        assertThat(violations.get(2).messageKey()).isEqualTo("object.notNull");
+    }
+
+    @Test
+    public void overrideMessage() {
+        Validator<User> validator = ValidatorBuilder.<User>of() //
+                .constraint(User::getName, "name", c -> c.notNull().message("name is required!") //
+                        .greaterThanOrEqual(1).message("name is too small!") //
+                        .lessThanOrEqual(20).message("name is too large!")) //
+                .build();
+        {
+            User user = new User(null, "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is required!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("object.notNull");
+        }
+        {
+            User user = new User("", "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is too small!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.greaterThanOrEqual");
+        }
+        {
+            User user = new User("012345678901234567890", "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is too large!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+    }
+
+    @Test
+    public void overrideViolationMessage() {
+        Validator<User> validator = ValidatorBuilder.<User>of() //
+                .constraint(User::getName, "name",
+                        c -> c.notNull().message(ViolationMessage.of("a", "name is required!")) //
+                                .greaterThanOrEqual(1).message(ViolationMessage.of("b", "name is too small!")) //
+                                .lessThanOrEqual(20).message(ViolationMessage.of("c", "name is too large!"))) //
+                .build();
+        {
+            User user = new User(null, "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is required!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("a");
+        }
+        {
+            User user = new User("", "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is too small!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("b");
+        }
+        {
+            User user = new User("012345678901234567890", "a@b.c", 10);
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("name is too large!");
+            assertThat(violations.get(0).messageKey()).isEqualTo("c");
+        }
+    }
+
+    @Test
+    public void throwIfInValidInValid() throws Exception {
+        User user = new User("foo", "foo@example.com", -1);
+        try {
+            validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
+            fail("fail");
+        } catch (ConstraintViolationsException e) {
+            ConstraintViolations violations = e.getViolations();
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message()).isEqualTo("\"age\" must be greater than or equal to 0");
+            assertThat(violations.get(0).messageKey()).isEqualTo("numeric.greaterThanOrEqual");
+        }
+    }
+
+    @Test
+    public void throwIfInValidValid() throws Exception {
+        User user = new User("foo", "foo@example.com", 30);
+        validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
+    }
+
+    @Test
+    public void valid() throws Exception {
+        User user = new User("foo", "foo@example.com", 30);
+        Validator<User> validator = validator();
+        ConstraintViolations violations = validator.validate(user);
+        assertThat(violations.isValid()).isTrue();
+    }
+
+    @Test
+    public void validateToEitherInValid() throws Exception {
+        User user = new User("foo", "foo@example.com", -1);
+        Either<ConstraintViolations, User> either = validator().validateToEither(user);
+        assertThat(either.isLeft()).isTrue();
+        ConstraintViolations violations = either.left().get();
+        assertThat(violations.isValid()).isFalse();
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.get(0).message()).isEqualTo("\"age\" must be greater than or equal to 0");
+        assertThat(violations.get(0).messageKey()).isEqualTo("numeric.greaterThanOrEqual");
+    }
+
+    @Test
+    public void validateToEitherValid() throws Exception {
+        User user = new User("foo", "foo@example.com", 30);
+        Either<ConstraintViolations, User> either = validator().validateToEither(user);
+        assertThat(either.isRight()).isTrue();
+        assertThat(either.right().get()).isSameAs(user);
+    }
+
+    @Test
+    public void violateGroupAndDefault() {
+        User user = new User("foobar", "foo@example.com", -1);
+        Validator<User> validator = ValidatorBuilder.of(User.class) //
+                .constraint(User::getEmail, "email", c -> c.email().lessThanOrEqual(10))
+                .constraintOnGroup(Group.UPDATE, //
+                        b -> b.constraint(User::getName, "name", c -> c.lessThanOrEqual(5))).build();
+        {
+            ConstraintViolations violations = validator.validate(user);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"email\" must be less than or equal to 10. The given size is 15");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+        {
+            ConstraintViolations violations = validator.validate(user, Group.UPDATE);
+            assertThat(violations.isValid()).isFalse();
+            assertThat(violations.size()).isEqualTo(2);
+            assertThat(violations.get(0).message())
+                    .isEqualTo("The size of \"email\" must be less than or equal to 10. The given size is 15");
+            assertThat(violations.get(0).messageKey()).isEqualTo("container.lessThanOrEqual");
+            assertThat(violations.get(1).message())
+                    .isEqualTo("The size of \"name\" must be less than or equal to 5. The given size is 6");
+            assertThat(violations.get(1).messageKey()).isEqualTo("container.lessThanOrEqual");
+        }
+    }
 }


### PR DESCRIPTION
I'm really thrilled to use YAVI. I tried it just yesterday and really liked it so far. But it isn't possible to generally overwrite the ViolationMessages or generate them dynamically based on some locale. With this PR one can overwrite the included messages generally and provide messages dynamically.