### PR TITLE
Support BiValidator that implements BiConsumer

### DIFF
--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -59,6 +59,7 @@ import am.ik.yavi.core.ConstraintCondition;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintPredicate;
 import am.ik.yavi.core.ConstraintPredicates;
+import am.ik.yavi.core.ConstraintViolations;
 import am.ik.yavi.core.CustomConstraint;
 import am.ik.yavi.core.NestedCollectionValidator;
 import am.ik.yavi.core.NestedConstraintCondition;

--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -52,6 +52,7 @@ import am.ik.yavi.constraint.array.IntArrayConstraint;
 import am.ik.yavi.constraint.array.LongArrayConstraint;
 import am.ik.yavi.constraint.array.ObjectArrayConstraint;
 import am.ik.yavi.constraint.array.ShortArrayConstraint;
+import am.ik.yavi.core.BiValidator;
 import am.ik.yavi.core.CollectionValidator;
 import am.ik.yavi.core.Constraint;
 import am.ik.yavi.core.ConstraintCondition;
@@ -148,6 +149,18 @@ public class ValidatorBuilder<T> {
 				this.collectionValidators, this.conditionalValidators,
 				this.messageFormatter == null ? new SimpleMessageFormatter()
 						: this.messageFormatter);
+	}
+
+	/**
+	 * Create a <code>BiValidator</code> instance using the given constraints.
+	 *
+	 * @param errorHandler handler that handle if the validation fails
+	 * @param <E> the type of the error object
+	 * @return <code>BiValidator</code> instance
+	 */
+	public <E> BiValidator<T, E> build(BiValidator.ErrorHandler<E> errorHandler) {
+		final Validator<T> validator = this.build();
+		return new BiValidator<>(validator, errorHandler);
 	}
 
 	public <E extends CharSequence> ValidatorBuilder<T> constraint(ToCharSequence<T, E> f,

--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -59,7 +59,6 @@ import am.ik.yavi.core.ConstraintCondition;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintPredicate;
 import am.ik.yavi.core.ConstraintPredicates;
-import am.ik.yavi.core.ConstraintViolations;
 import am.ik.yavi.core.CustomConstraint;
 import am.ik.yavi.core.NestedCollectionValidator;
 import am.ik.yavi.core.NestedConstraintCondition;

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -21,7 +21,7 @@ import java.util.function.BiConsumer;
  * <code>BiValidator</code> is a wrapper class of <code>Validator</code> that takes target
  * object to validate and arbitrary errors object. <br>
  * The result of validation is contained in the errors object instead of returning it.
- * This class is useful for a library to adopt both YAVI and other validation library such
+ * This class is useful for a library to adapt both YAVI and other validation library such
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *
  * @param <T> the type of the instance to validate

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -19,12 +19,12 @@ import java.util.function.BiConsumer;
 
 /**
  * <code>BiValidator</code> is a wrapper class of <code>Validator</code> that takes target
- * object to validate and arbitrary error object. <br>
+ * object to validate and arbitrary errors object. <br>
  * This class is useful for a library to adopt both YAVI and other validation library such
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *
  * @param <T> the type of the instance to validate
- * @param <E> the type of the error object
+ * @param <E> the type of the errors object
  * @author Toshiaki Maki
  * @since 0.5.0
  */
@@ -46,7 +46,7 @@ public class BiValidator<T, E> implements BiConsumer<T, E> {
 
 	@FunctionalInterface
 	public interface ErrorHandler<E> {
-		void handleError(E error, String name, String messageKey, Object[] args,
+		void handleError(E errors, String name, String messageKey, Object[] args,
 				String defaultMessage);
 	}
 }

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -24,6 +24,15 @@ import java.util.function.BiConsumer;
  * This class is useful for a library to adapt both YAVI and other validation library such
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *
+ * Validator can be wrapped as follows:
+ * <pre>
+ * Validator&lt;CartItem&gt; validator = ValidatorBuilder.&lt;CartItem&gt; of()
+ *                        .constraint(CartItem::getQuantity, "quantity", c -> c.greaterThan(0))
+ *                        .constraint(...)
+ *                        .build();
+ * BiValidator&lt;CartItem, Errors&gt; validator = new BiValidator&lt;&gt;(validator, Errors::rejectValue);
+ * </pre>
+ *
  * @param <T> the type of the instance to validate
  * @param <E> the type of the errors object
  * @author Toshiaki Maki

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.core;
+
+import java.util.function.BiConsumer;
+
+/**
+ * <code>BiValidator</code> is a wrapper class of <code>Validator</code> that takes target
+ * object to validate and arbitrary error object. <br>
+ * This class is useful for a library to adopt both YAVI and other validation library such
+ * as Spring Framework's <code>org.springframework.validation.Validator</code>.
+ *
+ * @param <T> the type of the instance to validate
+ * @param <E> the type of the error object
+ * @author Toshiaki Maki
+ * @since 0.5.0
+ */
+public class BiValidator<T, E> implements BiConsumer<T, E> {
+	private final Validator<T> validator;
+
+	private final ErrorHandler<E> errorHandler;
+
+	public BiValidator(Validator<T> validator, ErrorHandler<E> errorHandler) {
+		this.validator = validator;
+		this.errorHandler = errorHandler;
+	}
+
+	public void accept(T target, E errors) {
+		final ConstraintViolations violations = this.validator.validate(target);
+		violations.apply((name, messageKey, args, defaultMessage) -> this.errorHandler
+				.handleError(errors, name, messageKey, args, defaultMessage));
+	}
+
+	@FunctionalInterface
+	public interface ErrorHandler<E> {
+		void handleError(E error, String name, String messageKey, Object[] args,
+				String defaultMessage);
+	}
+}

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -20,6 +20,7 @@ import java.util.function.BiConsumer;
 /**
  * <code>BiValidator</code> is a wrapper class of <code>Validator</code> that takes target
  * object to validate and arbitrary errors object. <br>
+ * The result of validation is contained in the errors object instead of returning it.
  * This class is useful for a library to adopt both YAVI and other validation library such
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -25,6 +25,7 @@ import java.util.function.BiConsumer;
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *
  * Validator can be wrapped as follows:
+ * 
  * <pre>
  * Validator&lt;CartItem&gt; validator = ValidatorBuilder.&lt;CartItem&gt; of()
  *                        .constraint(CartItem::getQuantity, "quantity", c -> c.greaterThan(0))

--- a/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
@@ -38,6 +38,7 @@ import am.ik.yavi.message.MessageFormatter;
  * </pre>
  *
  * A component can create a validator like following:
+ * 
  * <pre>
  *{@literal @RestController}
  * public calls OrderController {

--- a/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
@@ -25,7 +25,29 @@ import am.ik.yavi.message.MessageFormatter;
 
 /**
  * A factory class of <code>BiValidator</code>. It can be used to manage the common
- * configurations of <code>BiValidator</code> in IoC container etc.
+ * configurations of <code>BiValidator</code> in IoC container etc.<br>
+ *
+ * In case of Spring Framework, you can define <code>BiValidatorFactory</code> as follows:
+ *
+ * <pre>
+ *{@literal @Bean}
+ * public BiValidatorFactory&lt;Errors&gt;(MessageSource messageSource) biValidatorFactory {
+ *   MessageFormatter messageFormatter = new MessageSourceMessageFormatter(messageSource::getMessage);
+ *   return new BiValidatorFactory&lt;&gt;(null, messageFormatter, Errors::rejectValues);
+ * }
+ * </pre>
+ *
+ * A component can create a validator like following:
+ * <pre>
+ *{@literal @RestController}
+ * public calls OrderController {
+ *     private final BiValidator&lt;CartItem, Errors&gt; validator;
+ *
+ *     public OrderController(BiValidatorFactory&lt;Errors&gt; factory) {
+ *         this.validator = factory.validator(builder -> builder.constraint(...));
+ *     }
+ * }
+ * </pre>
  *
  * @param <E> the type of the errors object
  * @author Toshiaki Maki

--- a/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.factory;
+
+import java.util.function.Function;
+
+import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.core.BiValidator;
+import am.ik.yavi.core.BiValidator.ErrorHandler;
+import am.ik.yavi.jsr305.Nullable;
+import am.ik.yavi.message.MessageFormatter;
+
+/**
+ * A factory class of <code>BiValidator</code>. It can be used to manage the common
+ * configurations of <code>BiValidator</code> in IoC container etc.
+ *
+ * @param <E> the type of the errors object
+ * @author Toshiaki Maki
+ * @since 0.5.0
+ */
+public class BiValidatorFactory<E> extends ValidatorFactorySupport {
+	private final BiValidator.ErrorHandler<E> errorHandler;
+
+	public BiValidatorFactory(@Nullable String messageKeySeparator,
+			@Nullable MessageFormatter messageFormatter,
+			@Nullable ErrorHandler<E> errorHandler) {
+		super(messageKeySeparator, messageFormatter);
+		this.errorHandler = errorHandler;
+	}
+
+	public BiValidatorFactory(@Nullable ErrorHandler<E> errorHandler) {
+		this(null, null, errorHandler);
+	}
+
+	public <T> BiValidator<T, E> validator(
+			Function<ValidatorBuilder<T>, ValidatorBuilder<T>> constraints) {
+		if (this.errorHandler == null) {
+			throw new IllegalArgumentException("'errorHandler' must not be null.");
+		}
+		final ValidatorBuilder<T> builder = super.initBuilder();
+		return constraints.apply(builder).build(this.errorHandler);
+	}
+}

--- a/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.factory;
+
+import java.util.function.Function;
+
+import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.core.Validator;
+import am.ik.yavi.jsr305.Nullable;
+import am.ik.yavi.message.MessageFormatter;
+
+/**
+ * A factory class of <code>Validator</code>. It can be used to manage the common
+ * configurations of <code>Validator</code> in IoC container etc.
+ *
+ * @author Toshiaki Maki
+ * @since 0.5.0
+ */
+public class ValidatorFactory extends ValidatorFactorySupport {
+
+	public ValidatorFactory() {
+		this(null, null);
+	}
+
+	public ValidatorFactory(@Nullable String messageKeySeparator,
+			@Nullable MessageFormatter messageFormatter) {
+		super(messageKeySeparator, messageFormatter);
+	}
+
+	public <T> Validator<T> validator(
+			Function<ValidatorBuilder<T>, ValidatorBuilder<T>> constraints) {
+		final ValidatorBuilder<T> builder = super.initBuilder();
+		return constraints.apply(builder).build();
+	}
+}

--- a/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
@@ -37,6 +37,7 @@ import am.ik.yavi.message.MessageFormatter;
  * </pre>
  *
  * A component can create a validator like following:
+ * 
  * <pre>
  *{@literal @RestController}
  * public calls OrderController {

--- a/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
@@ -24,7 +24,29 @@ import am.ik.yavi.message.MessageFormatter;
 
 /**
  * A factory class of <code>Validator</code>. It can be used to manage the common
- * configurations of <code>Validator</code> in IoC container etc.
+ * configurations of <code>Validator</code> in IoC container etc.<br>
+ *
+ * In case of Spring Framework, you can define <code>BiValidatorFactory</code> as follows:
+ *
+ * <pre>
+ *{@literal @Bean}
+ * public ValidatorFactory(MessageSource messageSource) validatorFactory {
+ *   MessageFormatter messageFormatter = new MessageSourceMessageFormatter(messageSource::getMessage);
+ *   return new ValidatorFactory(null, messageFormatter);
+ * }
+ * </pre>
+ *
+ * A component can create a validator like following:
+ * <pre>
+ *{@literal @RestController}
+ * public calls OrderController {
+ *     private final Validator&lt;CartItem&gt; validator;
+ *
+ *     public OrderController(ValidatorFactory factory) {
+ *         this.validator = factory.validator(builder -> builder.constraint(...));
+ *     }
+ * }
+ * </pre>
  *
  * @author Toshiaki Maki
  * @since 0.5.0

--- a/src/main/java/am/ik/yavi/factory/ValidatorFactorySupport.java
+++ b/src/main/java/am/ik/yavi/factory/ValidatorFactorySupport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.factory;
+
+import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.jsr305.Nullable;
+import am.ik.yavi.message.MessageFormatter;
+
+abstract class ValidatorFactorySupport {
+	protected final String messageKeySeparator;
+
+	protected final MessageFormatter messageFormatter;
+
+	protected ValidatorFactorySupport(@Nullable String messageKeySeparator,
+			@Nullable MessageFormatter messageFormatter) {
+		this.messageKeySeparator = messageKeySeparator;
+		this.messageFormatter = messageFormatter;
+	}
+
+	protected <T> ValidatorBuilder<T> initBuilder() {
+		final ValidatorBuilder<T> builder = this.messageKeySeparator == null
+				? new ValidatorBuilder<>()
+				: new ValidatorBuilder<>(this.messageKeySeparator);
+		if (this.messageFormatter != null) {
+			builder.messageFormatter(messageFormatter);
+		}
+		return builder;
+	}
+}

--- a/src/main/java/am/ik/yavi/factory/package-info.java
+++ b/src/main/java/am/ik/yavi/factory/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package am.ik.yavi.factory;
+
+import am.ik.yavi.jsr305.NonNullApi;

--- a/src/test/java/am/ik/yavi/core/BiValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/BiValidatorTest.java
@@ -1,0 +1,59 @@
+package am.ik.yavi.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import am.ik.yavi.User;
+import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.message.SimpleMessageFormatter;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BiValidatorTest {
+	final BiValidator<User, List<ConstraintViolation>> validator = ValidatorBuilder
+			.of(User.class)
+			.constraint(User::getName, "name",
+					c -> c.notNull().greaterThanOrEqual(1).lessThanOrEqual(20))
+			.constraint(User::getEmail, "email",
+					c -> c.notNull().greaterThanOrEqual(5).lessThanOrEqual(50).email())
+			.constraint(User::getAge, "age",
+					c -> c.notNull().greaterThanOrEqual(0).lessThanOrEqual(200))
+			.constraint(User::isEnabled, "enabled", c -> c.isTrue())
+			.build((errors, name, messageKey, args, defaultMessage) -> errors
+					.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
+							new SimpleMessageFormatter(), Locale.ENGLISH)));
+
+	@Test
+	public void allValid() throws Exception {
+		User user = new User("Demo", "demo@example.com", 100);
+		user.setEnabled(true);
+		final List<ConstraintViolation> violations = new ArrayList<>();
+
+		validator.accept(user, violations);
+		assertThat(violations.size()).isEqualTo(0);
+	}
+
+	@Test
+	public void allInvalid() throws Exception {
+		User user = new User("", "example.com", 300);
+		user.setEnabled(false);
+		final List<ConstraintViolation> violations = new ArrayList<>();
+
+		validator.accept(user, violations);
+		assertThat(violations.size()).isEqualTo(4);
+		assertThat(violations.get(0).message()).isEqualTo(
+				"The size of \"name\" must be greater than or equal to 1. The given size is 0");
+		assertThat(violations.get(0).messageKey())
+				.isEqualTo("container.greaterThanOrEqual");
+		assertThat(violations.get(1).message())
+				.isEqualTo("\"email\" must be a valid email address");
+		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.email");
+		assertThat(violations.get(2).message())
+				.isEqualTo("\"age\" must be less than or equal to 200");
+		assertThat(violations.get(2).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+		assertThat(violations.get(3).message()).isEqualTo("\"enabled\" must be true");
+		assertThat(violations.get(3).messageKey()).isEqualTo("boolean.isTrue");
+	}
+}

--- a/src/test/java/am/ik/yavi/message/MessageSourceMessageFormatterTest.java
+++ b/src/test/java/am/ik/yavi/message/MessageSourceMessageFormatterTest.java
@@ -27,9 +27,12 @@ class MessageSourceMessageFormatterTest {
 
 	@Test
 	void format() {
-		final MessageSource messageSource = (code, args, defaultMessage, locale) -> "Message " + code + " " + Arrays.toString(args);
-		final MessageSourceMessageFormatter messageFormatter = new MessageSourceMessageFormatter(messageSource);
-		final String message = messageFormatter.format("demo", "", new Object[] { 1, 2 }, Locale.ENGLISH);
+		final MessageSource messageSource = (code, args, defaultMessage,
+				locale) -> "Message " + code + " " + Arrays.toString(args);
+		final MessageSourceMessageFormatter messageFormatter = new MessageSourceMessageFormatter(
+				messageSource);
+		final String message = messageFormatter.format("demo", "", new Object[] { 1, 2 },
+				Locale.ENGLISH);
 		assertThat(message).isEqualTo("Message demo [1, 2]");
 	}
 }


### PR DESCRIPTION
so that a library can seamlessly adapt both YAVI
and other validation library such as Spring Framework's Validation.
For example: https://github.com/odrotbohm/spring-playground/commit/3e130e6e0be02836e8a219d765ff15f9561554fe

cc: @odrotbohm