### PR TITLE
Deprecate `clone` in favor of copy constructor in `ValidatorBuilder`.

### DIFF
--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -85,7 +85,7 @@ import am.ik.yavi.meta.ObjectConstraintMeta;
 import am.ik.yavi.meta.ShortConstraintMeta;
 import am.ik.yavi.meta.StringConstraintMeta;
 
-public class ValidatorBuilder<T> {
+public class ValidatorBuilder<T> implements Cloneable {
 	private static final String DEFAULT_SEPARATOR = ".";
 
 	final List<CollectionValidator<T, ?, ?>> collectionValidators = new ArrayList<>();
@@ -108,6 +108,15 @@ public class ValidatorBuilder<T> {
 		this.messageKeySeparator = messageKeySeparator;
 	}
 
+	public ValidatorBuilder(ValidatorBuilder<T> cloningSource) {
+		this(cloningSource.messageKeySeparator);
+		this.collectionValidators.addAll(cloningSource.collectionValidators);
+		this.conditionalValidators.addAll(cloningSource.conditionalValidators);
+		this.predicatesList.addAll(cloningSource.predicatesList);
+		this.messageFormatter = cloningSource.messageFormatter;
+		this.failFast = cloningSource.failFast;
+	}
+
 	@SuppressWarnings("unchecked")
 	public <S extends T> ValidatorBuilder<S> cast(Class<S> clazz) {
 		return (ValidatorBuilder<S>) this;
@@ -118,6 +127,11 @@ public class ValidatorBuilder<T> {
 		return (ValidatorBuilder<S>) this;
 	}
 
+	/**
+	 * @deprecated please use the copy constructor {@link #ValidatorBuilder(ValidatorBuilder)}
+	 * @return the cloned builder
+	 */
+	@Deprecated
 	public ValidatorBuilder<T> clone() {
 		final ValidatorBuilder<T> builder = new ValidatorBuilder<>(
 				this.messageKeySeparator);

--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -128,19 +128,13 @@ public class ValidatorBuilder<T> implements Cloneable {
 	}
 
 	/**
-	 * @deprecated please use the copy constructor {@link #ValidatorBuilder(ValidatorBuilder)}
+	 * @deprecated please use the copy constructor
+	 * {@link #ValidatorBuilder(ValidatorBuilder)}
 	 * @return the cloned builder
 	 */
 	@Deprecated
 	public ValidatorBuilder<T> clone() {
-		final ValidatorBuilder<T> builder = new ValidatorBuilder<>(
-				this.messageKeySeparator);
-		builder.collectionValidators.addAll(this.collectionValidators);
-		builder.conditionalValidators.addAll(this.conditionalValidators);
-		builder.predicatesList.addAll(this.predicatesList);
-		builder.messageFormatter = this.messageFormatter;
-		builder.failFast = this.failFast;
-		return builder;
+		return new ValidatorBuilder<>(this);
 	}
 
 	/**


### PR DESCRIPTION
Although the `clone` is implemented correctly it is advised to use a copy constructor instead of `clone`. 
I will just paste the SonarLint description too, to get a better insight why this change is needed

```
"clone" should not be overridden
 
Code smell         Blocker         java:S2975

Many consider clone and Cloneable broken in Java, largely because the rules for overriding clone are tricky and difficult to get right, according to Joshua Bloch:

'Object’s clone method is very tricky. It’s based on field copies, and it’s "extra-linguistic." It creates an object without calling a constructor. There are no guarantees that it preserves the invariants established by the constructors. There have been lots of bugs over the years, both in and outside Sun, stemming from the fact that if you just call super.clone repeatedly up the chain until you have cloned an object, you have a shallow copy of the object. The clone generally shares state with the object being cloned. If that state is mutable, you don’t have two independent objects. If you modify one, the other changes as well. And all of a sudden, you get random behavior.'

A copy constructor or copy factory should be used instead.
This rule raises an issue when clone is overridden, whether or not Cloneable is implemented.
```

Further can be read here: https://www.artima.com/articles/josh-bloch-on-design#part13