### PR TITLE
`positive()`, `negative()`, `positiveOrZero()` & `negativeOrZero()` introduced to `NumericConstraintBase`

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/BigDecimalConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BigDecimalConstraint.java
@@ -46,4 +46,14 @@ public class BigDecimalConstraint<T>
 	protected Predicate<BigDecimal> isLessThanOrEqual(BigDecimal max) {
 		return x -> x.compareTo(max) <= 0;
 	}
+
+	@Override
+	protected BigDecimal zeroValue() {
+		return BigDecimal.ZERO;
+	}
+
+	@Override
+	protected BigDecimal oneValue() {
+		return BigDecimal.ONE;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/BigDecimalConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BigDecimalConstraint.java
@@ -51,9 +51,4 @@ public class BigDecimalConstraint<T>
 	protected BigDecimal zeroValue() {
 		return BigDecimal.ZERO;
 	}
-
-	@Override
-	protected BigDecimal oneValue() {
-		return BigDecimal.ONE;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/BigIntegerConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BigIntegerConstraint.java
@@ -46,4 +46,14 @@ public class BigIntegerConstraint<T>
 	protected Predicate<BigInteger> isLessThanOrEqual(BigInteger max) {
 		return x -> x.compareTo(max) <= 0;
 	}
+
+	@Override
+	protected BigInteger zeroValue() {
+		return BigInteger.ZERO;
+	}
+
+	@Override
+	protected BigInteger oneValue() {
+		return BigInteger.ONE;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/BigIntegerConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/BigIntegerConstraint.java
@@ -51,9 +51,4 @@ public class BigIntegerConstraint<T>
 	protected BigInteger zeroValue() {
 		return BigInteger.ZERO;
 	}
-
-	@Override
-	protected BigInteger oneValue() {
-		return BigInteger.ONE;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/ByteConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/ByteConstraint.java
@@ -44,4 +44,14 @@ public class ByteConstraint<T> extends NumericConstraintBase<T, Byte, ByteConstr
 	protected Predicate<Byte> isLessThanOrEqual(Byte max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Byte zeroValue() {
+		return 0;
+	}
+
+	@Override
+	protected Byte oneValue() {
+		return 1;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/ByteConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/ByteConstraint.java
@@ -49,9 +49,4 @@ public class ByteConstraint<T> extends NumericConstraintBase<T, Byte, ByteConstr
 	protected Byte zeroValue() {
 		return 0;
 	}
-
-	@Override
-	protected Byte oneValue() {
-		return 1;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
@@ -48,6 +48,6 @@ public class CharacterConstraint<T>
 
 	@Override
 	protected Character zeroValue() {
-		return Character.MIN_VALUE;
+		return '0';
 	}
 }

--- a/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
@@ -45,4 +45,14 @@ public class CharacterConstraint<T>
 	protected Predicate<Character> isLessThanOrEqual(Character max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Character zeroValue() {
+		return Character.MIN_VALUE;
+	}
+
+	@Override
+	protected Character oneValue() {
+		return '1';
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
@@ -50,9 +50,4 @@ public class CharacterConstraint<T>
 	protected Character zeroValue() {
 		return Character.MIN_VALUE;
 	}
-
-	@Override
-	protected Character oneValue() {
-		return '1';
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharacterConstraint.java
@@ -48,6 +48,6 @@ public class CharacterConstraint<T>
 
 	@Override
 	protected Character zeroValue() {
-		return '0';
+		return Character.MIN_VALUE;
 	}
 }

--- a/src/main/java/am/ik/yavi/constraint/DoubleConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/DoubleConstraint.java
@@ -50,9 +50,4 @@ public class DoubleConstraint<T>
 	protected Double zeroValue() {
 		return 0.0;
 	}
-
-	@Override
-	protected Double oneValue() {
-		return 1.0;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/DoubleConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/DoubleConstraint.java
@@ -45,4 +45,14 @@ public class DoubleConstraint<T>
 	protected Predicate<Double> isLessThanOrEqual(Double max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Double zeroValue() {
+		return 0.0;
+	}
+
+	@Override
+	protected Double oneValue() {
+		return 1.0;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/FloatConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/FloatConstraint.java
@@ -45,4 +45,14 @@ public class FloatConstraint<T>
 	protected Predicate<Float> isLessThanOrEqual(Float max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Float zeroValue() {
+		return 0f;
+	}
+
+	@Override
+	protected Float oneValue() {
+		return 1f;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/FloatConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/FloatConstraint.java
@@ -50,9 +50,4 @@ public class FloatConstraint<T>
 	protected Float zeroValue() {
 		return 0f;
 	}
-
-	@Override
-	protected Float oneValue() {
-		return 1f;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/IntegerConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/IntegerConstraint.java
@@ -50,9 +50,4 @@ public class IntegerConstraint<T>
 	protected Integer zeroValue() {
 		return 0;
 	}
-
-	@Override
-	protected Integer oneValue() {
-		return 1;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/IntegerConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/IntegerConstraint.java
@@ -45,4 +45,14 @@ public class IntegerConstraint<T>
 	protected Predicate<Integer> isLessThanOrEqual(Integer max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Integer zeroValue() {
+		return 0;
+	}
+
+	@Override
+	protected Integer oneValue() {
+		return 1;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/LongConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/LongConstraint.java
@@ -49,9 +49,4 @@ public class LongConstraint<T> extends NumericConstraintBase<T, Long, LongConstr
 	protected Long zeroValue() {
 		return 0L;
 	}
-
-	@Override
-	protected Long oneValue() {
-		return 1L;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/LongConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/LongConstraint.java
@@ -44,4 +44,14 @@ public class LongConstraint<T> extends NumericConstraintBase<T, Long, LongConstr
 	protected Predicate<Long> isLessThanOrEqual(Long max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Long zeroValue() {
+		return 0L;
+	}
+
+	@Override
+	protected Long oneValue() {
+		return 1L;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/ShortConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/ShortConstraint.java
@@ -45,4 +45,14 @@ public class ShortConstraint<T>
 	protected Predicate<Short> isLessThanOrEqual(Short max) {
 		return x -> x <= max;
 	}
+
+	@Override
+	protected Short zeroValue() {
+		return 0;
+	}
+
+	@Override
+	protected Short oneValue() {
+		return 1;
+	}
 }

--- a/src/main/java/am/ik/yavi/constraint/ShortConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/ShortConstraint.java
@@ -50,9 +50,4 @@ public class ShortConstraint<T>
 	protected Short zeroValue() {
 		return 0;
 	}
-
-	@Override
-	protected Short oneValue() {
-		return 1;
-	}
 }

--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -18,10 +18,7 @@ package am.ik.yavi.constraint.base;
 import java.util.function.Predicate;
 
 import static am.ik.yavi.core.NullAs.VALID;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_GREATER_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_GREATER_THAN_OR_EQUAL;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_LESS_THAN;
-import static am.ik.yavi.core.ViolationMessage.Default.NUMERIC_LESS_THAN_OR_EQUAL;
+import static am.ik.yavi.core.ViolationMessage.Default.*;
 
 import am.ik.yavi.core.Constraint;
 import am.ik.yavi.core.ConstraintPredicate;
@@ -53,6 +50,18 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 		return cast();
 	}
 
+	public C positive() {
+		this.predicates().add(ConstraintPredicate.of(this.isGreaterThan(zeroValue()),
+				NUMERIC_POSITIVE, () -> new Object[] { }, VALID));
+		return cast();
+	}
+
+	public C negative() {
+		this.predicates().add(ConstraintPredicate.of(this.isLessThan(zeroValue()),
+				NUMERIC_NEGATIVE, () -> new Object[] { }, VALID));
+		return cast();
+	}
+
 	protected abstract Predicate<V> isGreaterThan(V min);
 
 	protected abstract Predicate<V> isGreaterThanOrEqual(V min);
@@ -60,4 +69,8 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 	protected abstract Predicate<V> isLessThan(V max);
 
 	protected abstract Predicate<V> isLessThanOrEqual(V max);
+
+	protected abstract V zeroValue();
+
+	protected abstract V oneValue();
 }

--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -52,13 +52,26 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 
 	public C positive() {
 		this.predicates().add(ConstraintPredicate.of(this.isGreaterThan(zeroValue()),
-				NUMERIC_POSITIVE, () -> new Object[] { }, VALID));
+				NUMERIC_POSITIVE, () -> new Object[] {}, VALID));
+		return cast();
+	}
+
+	public C positiveOrZero() {
+		this.predicates()
+				.add(ConstraintPredicate.of(this.isGreaterThanOrEqual(zeroValue()),
+						NUMERIC_POSITIVE_OR_ZERO, () -> new Object[] {}, VALID));
 		return cast();
 	}
 
 	public C negative() {
 		this.predicates().add(ConstraintPredicate.of(this.isLessThan(zeroValue()),
-				NUMERIC_NEGATIVE, () -> new Object[] { }, VALID));
+				NUMERIC_NEGATIVE, () -> new Object[] {}, VALID));
+		return cast();
+	}
+
+	public C negaitveOrZero() {
+		this.predicates().add(ConstraintPredicate.of(this.isLessThanOrEqual(zeroValue()),
+				NUMERIC_NEGATIVE_OR_ZERO, () -> new Object[] {}, VALID));
 		return cast();
 	}
 
@@ -71,6 +84,4 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 	protected abstract Predicate<V> isLessThanOrEqual(V max);
 
 	protected abstract V zeroValue();
-
-	protected abstract V oneValue();
 }

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -55,7 +55,11 @@ public interface ViolationMessage {
 		NUMERIC_LESS_THAN_OR_EQUAL("numeric.lessThanOrEqual",
 				"\"{0}\" must be less than or equal to {1}"), //
 		NUMERIC_POSITIVE("numeric.positive", "\"{0}\" must be positive"), //
+		NUMERIC_POSITIVE_OR_ZERO("numeric.positiveOrZero",
+				"\"{0}\" must be positive or zero"), //
 		NUMERIC_NEGATIVE("numeric.negative", "\"{0}\" must be negative"), //
+		NUMERIC_NEGATIVE_OR_ZERO("numeric.negativeOrZero",
+				"\"{0}\" must be negative or zero"), //
 		BOOLEAN_IS_TRUE("boolean.isTrue", "\"{0}\" must be true"), //
 		BOOLEAN_IS_FALSE("boolean.isFalse", "\"{0}\" must be false"), //
 		CHAR_SEQUENCE_NOT_BLANK("charSequence.notBlank", "\"{0}\" must not be blank"), //

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -54,6 +54,8 @@ public interface ViolationMessage {
 		NUMERIC_LESS_THAN("numeric.lessThan", "\"{0}\" must be less than {1}"), //
 		NUMERIC_LESS_THAN_OR_EQUAL("numeric.lessThanOrEqual",
 				"\"{0}\" must be less than or equal to {1}"), //
+		NUMERIC_POSITIVE("numeric.positive", "\"{0}\" must be positive"), //
+		NUMERIC_NEGATIVE("numeric.negative", "\"{0}\" must be negative"), //
 		BOOLEAN_IS_TRUE("boolean.isTrue", "\"{0}\" must be true"), //
 		BOOLEAN_IS_FALSE("boolean.isFalse", "\"{0}\" must be false"), //
 		CHAR_SEQUENCE_NOT_BLANK("charSequence.notBlank", "\"{0}\" must not be blank"), //

--- a/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
@@ -108,7 +108,7 @@ class BigDecimalConstraintTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "99", "100","0" })
+	@ValueSource(strings = { "99", "100", "0" })
 	void invalidNegative(BigDecimal value) {
 		Predicate<BigDecimal> predicate = retrievePredicate(
 				NumericConstraintBase::negative);
@@ -120,6 +120,38 @@ class BigDecimalConstraintTest {
 	void validNegative(BigDecimal value) {
 		Predicate<BigDecimal> predicate = retrievePredicate(
 				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100", "0" })
+	void validPositiveOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150" })
+	void invalidPositiveOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void invalidNegativeOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void validNegativeOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -88,6 +89,38 @@ class BigDecimalConstraintTest {
 		Predicate<BigDecimal> predicate = retrievePredicate(
 				c -> c.lessThanOrEqual(new BigDecimal("100")));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void validPositive(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void invalidPositive(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100","0" })
+	void invalidNegative(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150" })
+	void validNegative(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<BigDecimal> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
@@ -15,9 +15,11 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -88,6 +90,38 @@ class BigIntegerConstraintTest {
 		Predicate<BigInteger> predicate = retrievePredicate(
 				c -> c.lessThanOrEqual(new BigInteger("100")));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void validPositive(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void invalidPositive(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100","0" })
+	void invalidNegative(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150" })
+	void validNegative(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<BigInteger> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
@@ -109,7 +109,7 @@ class BigIntegerConstraintTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "99", "100","0" })
+	@ValueSource(strings = { "99", "100", "0" })
 	void invalidNegative(BigInteger value) {
 		Predicate<BigInteger> predicate = retrievePredicate(
 				NumericConstraintBase::negative);
@@ -121,6 +121,38 @@ class BigIntegerConstraintTest {
 	void validNegative(BigInteger value) {
 		Predicate<BigInteger> predicate = retrievePredicate(
 				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100", "0" })
+	void validPositiveOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150" })
+	void invalidPositiveOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void invalidNegativeOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void validNegativeOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
@@ -15,9 +15,11 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.math.BigInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -81,6 +83,38 @@ class ByteConstraintTest {
 	void invalidLessThanOrEqual(byte value) {
 		Predicate<Byte> predicate = retrievePredicate(c -> c.lessThanOrEqual((byte) 100));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void validPositive(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-1", "0" })
+	void invalidPositive(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100","0" })
+	void invalidNegative(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-10" })
+	void validNegative(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Byte> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
@@ -88,32 +88,60 @@ class ByteConstraintTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "99", "100" })
 	void validPositive(byte value) {
-		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Byte> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "-101", "-1", "0" })
 	void invalidPositive(byte value) {
-		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Byte> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "99", "100","0" })
+	@ValueSource(strings = { "99", "100", "0" })
 	void invalidNegative(byte value) {
-		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Byte> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "-101", "-10" })
 	void validNegative(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100", "0" })
+	void validPositiveOrZero(byte value) {
 		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-12" })
+	void invalidPositiveOrZero(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
+	void invalidNegativeOrZero(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-120", "0" })
+	void validNegativeOrZero(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/CharacterConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharacterConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -84,6 +85,30 @@ class CharacterConstraintTest {
 	void invalidLessThanOrEqual(char value) {
 		Predicate<Character> predicate = retrievePredicate(
 				c -> c.lessThanOrEqual((char) 100));
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(chars = { 99, 100 })
+	void validPositive(char value) {
+		Predicate<Character> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(chars = { 0 })
+	void invalidPositive(char value) {
+		Predicate<Character> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(chars = { 99, 100 })
+	void validNegative(char value) {
+		Predicate<Character> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
@@ -85,32 +85,60 @@ class DoubleConstraintTest {
 	@ParameterizedTest
 	@ValueSource(doubles = { 101.0, 150.0 })
 	void validPositive(double value) {
-		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Double> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(doubles = { -101.0, -150.0, 0 })
 	void invalidPositive(double value) {
-		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Double> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
-	@ValueSource(doubles = { 99.0, 100.0,0.0 })
+	@ValueSource(doubles = { 99.0, 100.0, 0.0 })
 	void invalidNegative(double value) {
-		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Double> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(doubles = { -100.0, -10.0 })
 	void validNegative(double value) {
+		Predicate<Double> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { 99.5, 100.5, 0 })
+	void validPositiveOrZero(double value) {
 		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { -101, -12 })
+	void invalidPositiveOrZero(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { 99.0, 100 })
+	void invalidNegativeOrZero(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { -101, -120, 0 })
+	void validNegativeOrZero(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -79,6 +80,38 @@ class DoubleConstraintTest {
 	void invalidLessThanOrEqual(double value) {
 		Predicate<Double> predicate = retrievePredicate(c -> c.lessThanOrEqual(100.0));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { 101.0, 150.0 })
+	void validPositive(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { -101.0, -150.0, 0 })
+	void invalidPositive(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { 99.0, 100.0,0.0 })
+	void invalidNegative(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { -100.0, -10.0 })
+	void validNegative(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Double> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -79,6 +80,38 @@ class FloatConstraintTest {
 	void invalidLessThanOrEqual(float value) {
 		Predicate<Float> predicate = retrievePredicate(c -> c.lessThanOrEqual(100.0f));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { 101.0f, 150.0f })
+	void validPositive(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { -101.0f, -150.0f, 0f })
+	void invalidPositive(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { 99f, 100f, 0f })
+	void invalidNegative(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { -100f, -10f })
+	void validNegative(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Float> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
@@ -85,32 +85,60 @@ class FloatConstraintTest {
 	@ParameterizedTest
 	@ValueSource(floats = { 101.0f, 150.0f })
 	void validPositive(float value) {
-		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Float> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(floats = { -101.0f, -150.0f, 0f })
 	void invalidPositive(float value) {
-		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Float> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(floats = { 99f, 100f, 0f })
 	void invalidNegative(float value) {
-		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Float> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(floats = { -100f, -10f })
 	void validNegative(float value) {
+		Predicate<Float> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { 99.5f, 100.5f, 0f })
+	void validPositiveOrZero(float value) {
 		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { -101f, -12f })
+	void invalidPositiveOrZero(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { 99.0f, 100f })
+	void invalidNegativeOrZero(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { -101f, -120f, 0f })
+	void validNegativeOrZero(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
@@ -85,32 +85,60 @@ class IntegerConstraintTest {
 	@ParameterizedTest
 	@ValueSource(ints = { 101, 150 })
 	void validPositive(int value) {
-		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Integer> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(ints = { -101, -150, 0 })
 	void invalidPositive(int value) {
-		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Integer> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(ints = { 9, 100, 0 })
 	void invalidNegative(int value) {
-		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Integer> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(ints = { -100, -10 })
 	void validNegative(int value) {
+		Predicate<Integer> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 99, 100, 0 })
+	void validPositiveOrZero(int value) {
 		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { -101, -12 })
+	void invalidPositiveOrZero(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 99, 100 })
+	void invalidNegativeOrZero(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { -101, -120, 0 })
+	void validNegativeOrZero(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -79,6 +80,38 @@ class IntegerConstraintTest {
 	void invalidLessThanOrEqual(int value) {
 		Predicate<Integer> predicate = retrievePredicate(c -> c.lessThanOrEqual(100));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 101, 150 })
+	void validPositive(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { -101, -150, 0 })
+	void invalidPositive(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 9, 100, 0 })
+	void invalidNegative(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { -100, -10 })
+	void validNegative(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Integer> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
@@ -85,32 +85,60 @@ class LongConstraintTest {
 	@ParameterizedTest
 	@ValueSource(longs = { 101L, 150L })
 	void validPositive(long value) {
-		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Long> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(longs = { -101L, -150L, 0L })
 	void invalidPositive(long value) {
-		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Long> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(longs = { 9L, 100L, 0L })
 	void invalidNegative(long value) {
-		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Long> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(longs = { -100L, -10L })
 	void validNegative(long value) {
+		Predicate<Long> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 99, 100, 0 })
+	void validPositiveOrZero(long value) {
 		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { -101, -12 })
+	void invalidPositiveOrZero(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 99, 100 })
+	void invalidNegativeOrZero(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { -101, -120, 0 })
+	void validNegativeOrZero(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -79,6 +80,38 @@ class LongConstraintTest {
 	void invalidLessThanOrEqual(long value) {
 		Predicate<Long> predicate = retrievePredicate(c -> c.lessThanOrEqual(100L));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 101L, 150L })
+	void validPositive(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { -101L, -150L, 0L })
+	void invalidPositive(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 9L, 100L, 0L })
+	void invalidNegative(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { -100L, -10L })
+	void validNegative(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Long> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
@@ -15,6 +15,7 @@
  */
 package am.ik.yavi.constraint;
 
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -83,6 +84,38 @@ class ShortConstraintTest {
 		Predicate<Short> predicate = retrievePredicate(
 				c -> c.lessThanOrEqual((short) 100));
 		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { 101, 10 })
+	void validPositive(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { -101, -10, 0 })
+	void invalidPositive(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::positive);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { 9, 100, 0 })
+	void invalidNegative(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { -100, -10 })
+	void validNegative(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
 	}
 
 	private static Predicate<Short> retrievePredicate(

--- a/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
@@ -89,32 +89,60 @@ class ShortConstraintTest {
 	@ParameterizedTest
 	@ValueSource(shorts = { 101, 10 })
 	void validPositive(short value) {
-		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Short> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(shorts = { -101, -10, 0 })
 	void invalidPositive(short value) {
-		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::positive);
+		Predicate<Short> predicate = retrievePredicate(NumericConstraintBase::positive);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(shorts = { 9, 100, 0 })
 	void invalidNegative(short value) {
-		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+		Predicate<Short> predicate = retrievePredicate(NumericConstraintBase::negative);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(shorts = { -100, -10 })
 	void validNegative(short value) {
+		Predicate<Short> predicate = retrievePredicate(NumericConstraintBase::negative);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { 99, 100, 0 })
+	void validPositiveOrZero(short value) {
 		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::negative);
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { -101, -12 })
+	void invalidPositiveOrZero(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::positiveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { 99, 100 })
+	void invalidNegativeOrZero(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { -101, -120, 0 })
+	void validNegativeOrZero(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -693,13 +693,12 @@ public class ValidatorTest {
 		}
 	}
 
-  	@Test
-  	public void agePositiveValidatorUserValid() {
-		User user = new User("Diego","foo@bar.com",10);
+	@Test
+	public void agePositiveValidatorUserValid() {
+		User user = new User("Diego", "foo@bar.com", 10);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
-				.constraint(User::getAge, "age", NumericConstraintBase::positive)
-				.build();
+				.constraint(User::getAge, "age", NumericConstraintBase::positive).build();
 
 		ConstraintViolations violations = validator.validate(user);
 		assertThat(violations.isValid()).isTrue();
@@ -707,11 +706,10 @@ public class ValidatorTest {
 
 	@Test
 	public void agePositiveValidatorUserInValid() {
-		User user = new User("Diego","foo@bar.com",-1);
+		User user = new User("Diego", "foo@bar.com", -1);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
-				.constraint(User::getAge, "age", NumericConstraintBase::positive)
-				.build();
+				.constraint(User::getAge, "age", NumericConstraintBase::positive).build();
 
 		ConstraintViolations violations = validator.validate(user);
 		assertThat(violations.isValid()).isFalse();
@@ -721,11 +719,10 @@ public class ValidatorTest {
 
 	@Test
 	public void ageNegativeValidatorUserValid() {
-		User user = new User("Diego","foo@bar.com",-1);
+		User user = new User("Diego", "foo@bar.com", -1);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
-				.constraint(User::getAge, "age", NumericConstraintBase::negative)
-				.build();
+				.constraint(User::getAge, "age", NumericConstraintBase::negative).build();
 
 		ConstraintViolations violations = validator.validate(user);
 		assertThat(violations.isValid()).isTrue();
@@ -733,11 +730,10 @@ public class ValidatorTest {
 
 	@Test
 	public void ageNegativeValidatorUserInValid() {
-		User user = new User("Diego","foo@bar.com",10);
+		User user = new User("Diego", "foo@bar.com", 10);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
-				.constraint(User::getAge, "age", NumericConstraintBase::negative)
-				.build();
+				.constraint(User::getAge, "age", NumericConstraintBase::negative).build();
 
 		ConstraintViolations violations = validator.validate(user);
 		assertThat(violations.isValid()).isFalse();

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -24,6 +24,7 @@ import am.ik.yavi.ConstraintViolationsException;
 import am.ik.yavi.Range;
 import am.ik.yavi.User;
 import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.constraint.base.NumericConstraintBase;
 import am.ik.yavi.constraint.charsequence.CodePoints;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsRanges;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
@@ -690,6 +691,58 @@ public class ValidatorTest {
 			assertThat(violations.get(1).messageKey())
 					.isEqualTo("container.lessThanOrEqual");
 		}
+	}
+
+  	@Test
+  	public void agePositiveValidatorUserValid() {
+		User user = new User("Diego","foo@bar.com",10);
+
+		Validator<User> validator = ValidatorBuilder.<User> of()
+				.constraint(User::getAge, "age", NumericConstraintBase::positive)
+				.build();
+
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void agePositiveValidatorUserInValid() {
+		User user = new User("Diego","foo@bar.com",-1);
+
+		Validator<User> validator = ValidatorBuilder.<User> of()
+				.constraint(User::getAge, "age", NumericConstraintBase::positive)
+				.build();
+
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo("\"age\" must be positive");
+	}
+
+	@Test
+	public void ageNegativeValidatorUserValid() {
+		User user = new User("Diego","foo@bar.com",-1);
+
+		Validator<User> validator = ValidatorBuilder.<User> of()
+				.constraint(User::getAge, "age", NumericConstraintBase::negative)
+				.build();
+
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	public void ageNegativeValidatorUserInValid() {
+		User user = new User("Diego","foo@bar.com",10);
+
+		Validator<User> validator = ValidatorBuilder.<User> of()
+				.constraint(User::getAge, "age", NumericConstraintBase::negative)
+				.build();
+
+		ConstraintViolations violations = validator.validate(user);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).isEqualTo("\"age\" must be negative");
 	}
 
 	Validator<User> validator() {


### PR DESCRIPTION
Previously we had to use `NumericConstraintBase#isGreaterThan(0)` to check if a given numeric value is positive. This is quite inconvenient, therefore I introduced `NumericConstraintBase#positive()`. As a counterpart to `positive()` I added `negative()` too.