### PR TITLE
Fully migrated test from JUnit4 to JUnit5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.version}</version>

--- a/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorTest.java
@@ -39,7 +39,7 @@ import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ArgumentsValidatorTest {
+class ArgumentsValidatorTest {
 
 	final Arguments1Validator<String, Country> arguments1Validator = ArgumentsValidatorBuilder
 			.of(Country::new) //

--- a/src/test/java/am/ik/yavi/constraint/array/ByteArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/ByteArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ByteArrayConstraintTest {
+class ByteArrayConstraintTest {
 	private ByteArrayConstraint<byte[]> constraint = new ByteArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<byte[]> predicate = constraint.contains((byte) 100).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100, (byte) 101 })).isTrue();
@@ -33,7 +33,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<byte[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100 })).isFalse();
@@ -43,7 +43,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<byte[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100, (byte) 101 })).isFalse();
@@ -52,7 +52,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<byte[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100 })).isFalse();
@@ -62,7 +62,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<byte[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100 })).isTrue();
@@ -70,7 +70,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<byte[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100 })).isTrue();
@@ -80,7 +80,7 @@ public class ByteArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<byte[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new byte[] { (byte) 100 })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/CharArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/CharArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CharArrayConstraintTest {
+class CharArrayConstraintTest {
 	private CharArrayConstraint<char[]> constraint = new CharArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<char[]> predicate = constraint.contains((char) 100).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new char[] { (char) 100, (char) 101 })).isTrue();
@@ -33,7 +33,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<char[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new char[] { (char) 100 })).isFalse();
@@ -43,7 +43,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<char[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new char[] { (char) 100, (char) 101 })).isFalse();
@@ -52,7 +52,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<char[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new char[] { (char) 100 })).isFalse();
@@ -62,7 +62,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<char[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new char[] { (char) 100 })).isTrue();
@@ -70,7 +70,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<char[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new char[] { (char) 100 })).isTrue();
@@ -80,7 +80,7 @@ public class CharArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<char[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new char[] { (char) 100 })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/DoubleArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/DoubleArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DoubleArrayConstraintTest {
+class DoubleArrayConstraintTest {
 	private DoubleArrayConstraint<double[]> constraint = new DoubleArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<double[]> predicate = constraint.contains(100.0).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new double[] { 100.0, 101.0 })).isTrue();
@@ -33,7 +33,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<double[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new double[] { 100.0 })).isFalse();
@@ -42,7 +42,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<double[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new double[] { 100.0, 101.0 })).isFalse();
@@ -50,7 +50,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<double[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new double[] { 100.0 })).isFalse();
@@ -59,7 +59,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<double[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new double[] { 100.0 })).isTrue();
@@ -67,7 +67,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<double[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new double[] { 100.0 })).isTrue();
@@ -76,7 +76,7 @@ public class DoubleArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<double[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new double[] { 100.0 })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/FloatArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/FloatArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FloatArrayConstraintTest {
+class FloatArrayConstraintTest {
 	private FloatArrayConstraint<float[]> constraint = new FloatArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<float[]> predicate = constraint.contains(100.0f).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new float[] { 100.0f, 101.0f })).isTrue();
@@ -33,7 +33,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<float[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new float[] { 100.0f })).isFalse();
@@ -42,7 +42,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<float[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new float[] { 100.0f, 101.0f })).isFalse();
@@ -50,7 +50,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<float[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new float[] { 100.0f })).isFalse();
@@ -59,7 +59,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<float[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new float[] { 100.0f })).isTrue();
@@ -67,7 +67,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<float[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new float[] { 100.0f })).isTrue();
@@ -76,7 +76,7 @@ public class FloatArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<float[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new float[] { 100.0f })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/IntArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/IntArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class IntArrayConstraintTest {
+class IntArrayConstraintTest {
 	private IntArrayConstraint<int[]> constraint = new IntArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<int[]> predicate = constraint.contains(100).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new int[] { 100, 101 })).isTrue();
@@ -33,7 +33,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<int[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new int[] { 100 })).isFalse();
@@ -42,7 +42,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<int[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new int[] { 100, 101 })).isFalse();
@@ -50,7 +50,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<int[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new int[] { 100 })).isFalse();
@@ -59,7 +59,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<int[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new int[] { 100 })).isTrue();
@@ -67,7 +67,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<int[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new int[] { 100 })).isTrue();
@@ -76,7 +76,7 @@ public class IntArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<int[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new int[] { 100 })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/LongArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/LongArrayConstraintTest.java
@@ -17,15 +17,15 @@ package am.ik.yavi.constraint.array;
 
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LongArrayConstraintTest {
+class LongArrayConstraintTest {
 	private LongArrayConstraint<long[]> constraint = new LongArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<long[]> predicate = constraint.contains(100L).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new long[] { 100L, 101L })).isTrue();
@@ -33,7 +33,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<long[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new long[] { 100L })).isFalse();
@@ -42,7 +42,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<long[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new long[] { 100L, 101L })).isFalse();
@@ -50,7 +50,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<long[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new long[] { 100L })).isFalse();
@@ -59,7 +59,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<long[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new long[] { 100L })).isTrue();
@@ -67,7 +67,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<long[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new long[] { 100L })).isTrue();
@@ -76,7 +76,7 @@ public class LongArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<long[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new long[] { 100L })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/ObjectArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/ObjectArrayConstraintTest.java
@@ -15,17 +15,17 @@
  */
 package am.ik.yavi.constraint.array;
 
-import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ObjectArrayConstraintTest {
+class ObjectArrayConstraintTest {
 	private ObjectArrayConstraint<String[], String> constraint = new ObjectArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<String[]> predicate = constraint.contains("foo").predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new String[] { "foo", "bar" })).isTrue();
@@ -33,7 +33,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<String[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new String[] { "foo" })).isFalse();
@@ -42,7 +42,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<String[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new String[] { "foo", "bar" })).isFalse();
@@ -50,7 +50,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<String[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new String[] { "foo" })).isFalse();
@@ -59,7 +59,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<String[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new String[] { "foo" })).isTrue();
@@ -67,7 +67,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<String[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new String[] { "foo" })).isTrue();
@@ -76,7 +76,7 @@ public class ObjectArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<String[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new String[] { "foo" })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/array/ShortArrayConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/array/ShortArrayConstraintTest.java
@@ -17,15 +17,15 @@ package am.ik.yavi.constraint.array;
 
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ShortArrayConstraintTest {
+class ShortArrayConstraintTest {
 	private ShortArrayConstraint<short[]> constraint = new ShortArrayConstraint<>();
 
 	@Test
-	public void contains() {
+	void contains() {
 		Predicate<short[]> predicate = constraint.contains((short) 100).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new short[] { (short) 100, (short) 101 })).isTrue();
@@ -33,7 +33,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<short[]> predicate = constraint.fixedSize(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new short[] { (short) 100 })).isFalse();
@@ -43,7 +43,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<short[]> predicate = constraint.greaterThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new short[] { (short) 100, (short) 101 })).isFalse();
@@ -52,7 +52,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<short[]> predicate = constraint.greaterThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new short[] { (short) 100 })).isFalse();
@@ -62,7 +62,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<short[]> predicate = constraint.lessThan(2).predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new short[] { (short) 100 })).isTrue();
@@ -70,7 +70,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<short[]> predicate = constraint.lessThanOrEqual(2).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test(new short[] { (short) 100 })).isTrue();
@@ -80,7 +80,7 @@ public class ShortArrayConstraintTest {
 	}
 
 	@Test
-	public void notEmpty() {
+	void notEmpty() {
 		Predicate<short[]> predicate = constraint.notEmpty().predicates().peekFirst()
 				.predicate();
 		assertThat(predicate.test(new short[] { (short) 100 })).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/charsequence/ByteSizeConstraintTest.java
@@ -17,17 +17,17 @@ package am.ik.yavi.constraint.charsequence;
 
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import am.ik.yavi.constraint.CharSequenceConstraint;
 
-public class ByteSizeConstraintTest {
+class ByteSizeConstraintTest {
 	private CharSequenceConstraint<String, String> constraint = new CharSequenceConstraint<>();
 
 	@Test
-	public void fixedSize() {
+	void fixedSize() {
 		Predicate<String> predicate = constraint.asByteArray().fixedSize(4).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test("abcd")).isTrue();
@@ -38,7 +38,7 @@ public class ByteSizeConstraintTest {
 	}
 
 	@Test
-	public void greaterThan() {
+	void greaterThan() {
 		Predicate<String> predicate = constraint.asByteArray().greaterThan(3).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test("abcd")).isTrue();
@@ -47,7 +47,7 @@ public class ByteSizeConstraintTest {
 	}
 
 	@Test
-	public void greaterThanOrEqual() {
+	void greaterThanOrEqual() {
 		Predicate<String> predicate = constraint.asByteArray().greaterThanOrEqual(3)
 				.predicates().peekFirst().predicate();
 		assertThat(predicate.test("abcd")).isTrue();
@@ -57,7 +57,7 @@ public class ByteSizeConstraintTest {
 	}
 
 	@Test
-	public void lessThan() {
+	void lessThan() {
 		Predicate<String> predicate = constraint.asByteArray().lessThan(3).predicates()
 				.peekFirst().predicate();
 		assertThat(predicate.test("ab")).isTrue();
@@ -66,7 +66,7 @@ public class ByteSizeConstraintTest {
 	}
 
 	@Test
-	public void lessThanOrEqual() {
+	void lessThanOrEqual() {
 		Predicate<String> predicate = constraint.asByteArray().lessThanOrEqual(3)
 				.predicates().peekFirst().predicate();
 		assertThat(predicate.test("ab")).isTrue();

--- a/src/test/java/am/ik/yavi/constraint/charsequence/CodePointsConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/charsequence/CodePointsConstraintTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,10 +29,10 @@ import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
 import am.ik.yavi.constraint.charsequence.CodePoints.Range;
 import am.ik.yavi.core.ConstraintPredicate;
 
-public class CodePointsConstraintTest {
+class CodePointsConstraintTest {
 
 	@Test
-	public void allIncludedRange() {
+	void allIncludedRange() {
 		CodePointsRanges<String> whiteList = () -> Arrays.asList(
 				Range.of(0x0041/* A */, 0x005A /* Z */),
 				Range.of(0x0061/* a */, 0x007A /* z */));
@@ -50,7 +50,7 @@ public class CodePointsConstraintTest {
 	}
 
 	@Test
-	public void allIncludedSet() {
+	void allIncludedSet() {
 		CodePointsSet<String> whiteList = () -> new HashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
 						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
@@ -80,7 +80,7 @@ public class CodePointsConstraintTest {
 	}
 
 	@Test
-	public void notIncludedRange() {
+	void notIncludedRange() {
 		CodePointsRanges<String> blackList = () -> Arrays.asList(
 				Range.of(0x0041/* A */, 0x0042 /* B */),
 				Range.of(0x0061/* a */, 0x0062 /* b */));
@@ -97,7 +97,7 @@ public class CodePointsConstraintTest {
 	}
 
 	@Test
-	public void notIncludedSet() {
+	void notIncludedSet() {
 		CodePointsSet<String> blackList = () -> new HashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */));
 

--- a/src/test/java/am/ik/yavi/constraint/charsequence/EmojiTest.java
+++ b/src/test/java/am/ik/yavi/constraint/charsequence/EmojiTest.java
@@ -19,52 +19,52 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EmojiTest {
+class EmojiTest {
 
 	@Test
-	public void elf() {
+	void elf() {
 		String emoji = "🧝🧝🏻🧝🏼🧝🏽🧝🏾🧝🏿";
 		assertThat(emoji.length()).isEqualTo(22);
 		assertThat(Emoji.bestEffortCount(emoji)).isEqualTo(6);
 	}
 
 	@Test
-	public void emoji() {
+	void emoji() {
 		String emoji = "I am 👱🏿";
 		assertThat(emoji.length()).isEqualTo(9);
 		assertThat(Emoji.bestEffortCount(emoji)).isEqualTo(6);
 	}
 
 	@Test
-	public void emoji11All() throws Exception {
+	void emoji11All() throws Exception {
 		verifyEmojiAll("emoji-test-11.txt");
 	}
 
 	@Test
-	public void emoji12All() throws Exception {
+	void emoji12All() throws Exception {
 		verifyEmojiAll("emoji-test-12.txt");
 	}
 
 	@Test
-	public void family() {
+	void family() {
 		String emoji = "👩‍❤️‍💋‍👩👪👩‍👩‍👧‍👦👨‍👦‍👦👨‍👧👩‍👧";
 		assertThat(emoji.length()).isEqualTo(42);
 		assertThat(Emoji.bestEffortCount(emoji)).isEqualTo(6);
 	}
 
 	@Test
-	public void heart() {
+	void heart() {
 		String emoji = "❤️💙💚💛🧡💜🖤";
 		assertThat(emoji.length()).isEqualTo(14);
 		assertThat(Emoji.bestEffortCount(emoji)).isEqualTo(7);
 	}
 
 	@Test
-	public void subdivisionFlags() {
+	void subdivisionFlags() {
 		String emoji = "🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿🏴󠁧󠁢󠁷󠁬󠁳󠁿";
 		assertThat(emoji.length()).isEqualTo(42);
 		assertThat(Emoji.bestEffortCount(emoji)).isEqualTo(3);

--- a/src/test/java/am/ik/yavi/constraint/charsequence/RangeTest.java
+++ b/src/test/java/am/ik/yavi/constraint/charsequence/RangeTest.java
@@ -16,14 +16,14 @@
 package am.ik.yavi.constraint.charsequence;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import am.ik.yavi.constraint.charsequence.CodePoints.Range;
 
-public class RangeTest {
+class RangeTest {
 
 	@Test
-	public void ofString() {
+	void ofString() {
 		Range range = Range.of("a", "z");
 		Assertions.assertThat(range).isEqualTo(Range.of(0x0061 /* a */, 0x007a /* z */));
 	}

--- a/src/test/java/am/ik/yavi/constraint/charsequence/codepoints/CompositeCodePointsTest.java
+++ b/src/test/java/am/ik/yavi/constraint/charsequence/codepoints/CompositeCodePointsTest.java
@@ -18,7 +18,7 @@ package am.ik.yavi.constraint.charsequence.codepoints;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static am.ik.yavi.constraint.charsequence.codepoints.UnicodeCodePoints.HIRAGANA;
 import static am.ik.yavi.constraint.charsequence.codepoints.UnicodeCodePoints.KATAKANA;
@@ -27,10 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import am.ik.yavi.constraint.charsequence.CodePoints;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
 
-public class CompositeCodePointsTest {
+class CompositeCodePointsTest {
 
 	@Test
-	public void codePointRange() {
+	void codePointRange() {
 		CodePoints<String> codePoints = new CompositeCodePoints<>(HIRAGANA, KATAKANA);
 		assertThat(codePoints.allExcludedCodePoints("あ")).isEmpty();
 		assertThat(codePoints.allExcludedCodePoints("い")).isEmpty();
@@ -45,7 +45,7 @@ public class CompositeCodePointsTest {
 	}
 
 	@Test
-	public void codePointsSet() {
+	void codePointsSet() {
 		CodePointsSet<String> cp1 = () -> new LinkedHashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */));
 		CodePointsSet<String> cp2 = () -> new LinkedHashSet<>(
@@ -64,7 +64,7 @@ public class CompositeCodePointsTest {
 	}
 
 	@Test
-	public void mix() {
+	void mix() {
 		CodePointsSet<String> cp1 = () -> new LinkedHashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */));
 		CodePointsSet<String> cp2 = () -> new LinkedHashSet<>(

--- a/src/test/java/am/ik/yavi/core/AbstractArrayValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/AbstractArrayValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,9 +24,9 @@ import am.ik.yavi.Country;
 import am.ik.yavi.FormWithArray;
 import am.ik.yavi.PhoneNumber;
 
-public abstract class AbstractArrayValidatorTest {
+abstract class AbstractArrayValidatorTest {
 	@Test
-	public void allInvalid() throws Exception {
+	void allInvalid() throws Exception {
 		Validator<FormWithArray> validator = validator();
 		FormWithArray form = new FormWithArray(
 				new Address[] { new Address(new Country(null), null, new PhoneNumber("")),
@@ -63,7 +63,7 @@ public abstract class AbstractArrayValidatorTest {
 	}
 
 	@Test
-	public void inValidOne() throws Exception {
+	void inValidOne() throws Exception {
 		Validator<FormWithArray> validator = validator();
 
 		FormWithArray form = new FormWithArray(new Address[] {
@@ -88,7 +88,7 @@ public abstract class AbstractArrayValidatorTest {
 	}
 
 	@Test
-	public void nullCollectionInValid() throws Exception {
+	void nullCollectionInValid() throws Exception {
 		Validator<FormWithArray> validator = validator();
 
 		FormWithArray form = new FormWithArray(null);
@@ -101,7 +101,7 @@ public abstract class AbstractArrayValidatorTest {
 	}
 
 	@Test
-	public void nullElement() throws Exception {
+	void nullElement() throws Exception {
 		Validator<FormWithArray> validator = validator();
 
 		FormWithArray form = new FormWithArray(new Address[] {
@@ -113,7 +113,7 @@ public abstract class AbstractArrayValidatorTest {
 	}
 
 	@Test
-	public void valid() throws Exception {
+	void valid() throws Exception {
 		Validator<FormWithArray> validator = validator();
 		FormWithArray form = new FormWithArray(new Address[] {
 				new Address(new Country("JP"), "tokyo", new PhoneNumber("0123456789")),

--- a/src/test/java/am/ik/yavi/core/AbstractCollectionValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/AbstractCollectionValidatorTest.java
@@ -17,7 +17,7 @@ package am.ik.yavi.core;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,9 +26,9 @@ import am.ik.yavi.Country;
 import am.ik.yavi.FormWithCollection;
 import am.ik.yavi.PhoneNumber;
 
-public abstract class AbstractCollectionValidatorTest {
+abstract class AbstractCollectionValidatorTest {
 	@Test
-	public void allInvalid() throws Exception {
+	void allInvalid() throws Exception {
 		Validator<FormWithCollection> validator = validator();
 		FormWithCollection form = new FormWithCollection(
 				Arrays.asList(new Address(new Country(null), null, new PhoneNumber("")),
@@ -65,7 +65,7 @@ public abstract class AbstractCollectionValidatorTest {
 	}
 
 	@Test
-	public void inValidOne() throws Exception {
+	void inValidOne() throws Exception {
 		Validator<FormWithCollection> validator = validator();
 
 		FormWithCollection form = new FormWithCollection(Arrays.asList(
@@ -90,7 +90,7 @@ public abstract class AbstractCollectionValidatorTest {
 	}
 
 	@Test
-	public void nullCollectionInValid() throws Exception {
+	void nullCollectionInValid() throws Exception {
 		Validator<FormWithCollection> validator = validator();
 
 		FormWithCollection form = new FormWithCollection(null);
@@ -103,7 +103,7 @@ public abstract class AbstractCollectionValidatorTest {
 	}
 
 	@Test
-	public void nullElement() throws Exception {
+	void nullElement() throws Exception {
 		Validator<FormWithCollection> validator = validator();
 
 		FormWithCollection form = new FormWithCollection(Arrays.asList(
@@ -115,7 +115,7 @@ public abstract class AbstractCollectionValidatorTest {
 	}
 
 	@Test
-	public void valid() throws Exception {
+	void valid() throws Exception {
 		Validator<FormWithCollection> validator = validator();
 		FormWithCollection form = new FormWithCollection(Arrays.asList(
 				new Address(new Country("JP"), "tokyo", new PhoneNumber("0123456789")),

--- a/src/test/java/am/ik/yavi/core/AbstractMapValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/AbstractMapValidatorTest.java
@@ -17,7 +17,7 @@ package am.ik.yavi.core;
 
 import java.util.LinkedHashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,9 +26,9 @@ import am.ik.yavi.Country;
 import am.ik.yavi.FormWithMap;
 import am.ik.yavi.PhoneNumber;
 
-public abstract class AbstractMapValidatorTest {
+abstract class AbstractMapValidatorTest {
 	@Test
-	public void allInvalid() throws Exception {
+	void allInvalid() throws Exception {
 		Validator<FormWithMap> validator = validator();
 		FormWithMap form = new FormWithMap(new LinkedHashMap<String, Address>() {
 			{
@@ -68,7 +68,7 @@ public abstract class AbstractMapValidatorTest {
 	}
 
 	@Test
-	public void inValidOne() throws Exception {
+	void inValidOne() throws Exception {
 		Validator<FormWithMap> validator = validator();
 		FormWithMap form = new FormWithMap(new LinkedHashMap<String, Address>() {
 			{
@@ -96,7 +96,7 @@ public abstract class AbstractMapValidatorTest {
 	}
 
 	@Test
-	public void nullCollectionInValid() throws Exception {
+	void nullCollectionInValid() throws Exception {
 		Validator<FormWithMap> validator = validator();
 
 		FormWithMap form = new FormWithMap(null);
@@ -109,7 +109,7 @@ public abstract class AbstractMapValidatorTest {
 	}
 
 	@Test
-	public void nullElement() throws Exception {
+	void nullElement() throws Exception {
 		Validator<FormWithMap> validator = validator();
 		FormWithMap form = new FormWithMap(new LinkedHashMap<String, Address>() {
 			{
@@ -124,7 +124,7 @@ public abstract class AbstractMapValidatorTest {
 	}
 
 	@Test
-	public void valid() throws Exception {
+	void valid() throws Exception {
 		Validator<FormWithMap> validator = validator();
 		FormWithMap form = new FormWithMap(new LinkedHashMap<String, Address>() {
 			{

--- a/src/test/java/am/ik/yavi/core/AbstractNestedValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/AbstractNestedValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,10 +23,10 @@ import am.ik.yavi.Address;
 import am.ik.yavi.Country;
 import am.ik.yavi.PhoneNumber;
 
-public abstract class AbstractNestedValidatorTest {
+abstract class AbstractNestedValidatorTest {
 
 	@Test
-	public void invalid() {
+	void invalid() {
 		Validator<Address> addressValidator = validator();
 		Address address = new Address(new Country(null), null, new PhoneNumber(""));
 		ConstraintViolations violations = addressValidator.validate(address);
@@ -47,7 +47,7 @@ public abstract class AbstractNestedValidatorTest {
 	}
 
 	@Test
-	public void nestedValueIsNull() {
+	void nestedValueIsNull() {
 		Validator<Address> addressValidator = validator();
 		Address address = new Address(null, null, null /* nullValidity */);
 		ConstraintViolations violations = addressValidator.validate(address);
@@ -60,7 +60,7 @@ public abstract class AbstractNestedValidatorTest {
 	}
 
 	@Test
-	public void valid() {
+	void valid() {
 		Validator<Address> addressValidator = validator();
 		Address address = new Address(new Country("JP"), "tokyo",
 				new PhoneNumber("0123456789"));

--- a/src/test/java/am/ik/yavi/core/ArrayValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ArrayValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +25,7 @@ import am.ik.yavi.FormWithArray;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class ArrayValidatorTest extends AbstractArrayValidatorTest {
+class ArrayValidatorTest extends AbstractArrayValidatorTest {
 	Validator<Address> addressValidator = ValidatorBuilder.<Address> of()
 			.constraint(Address::street, "street", c -> c.notBlank().lessThan(32))
 			.nest(Address::country, "country", Country.validator())
@@ -33,7 +33,7 @@ public class ArrayValidatorTest extends AbstractArrayValidatorTest {
 			.build();
 
 	@Test
-	public void nullCollectionValid() throws Exception {
+	void nullCollectionValid() throws Exception {
 		Validator<FormWithArray> validator = ValidatorBuilder.of(FormWithArray.class) //
 				.forEachIfPresent(FormWithArray::getAddresses, "addresses",
 						addressValidator)

--- a/src/test/java/am/ik/yavi/core/BiValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/BiValidatorTest.java
@@ -22,11 +22,11 @@ import java.util.Locale;
 import am.ik.yavi.User;
 import am.ik.yavi.builder.ValidatorBuilder;
 import am.ik.yavi.message.SimpleMessageFormatter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BiValidatorTest {
+class BiValidatorTest {
 	final BiValidator<User, List<ConstraintViolation>> validator = ValidatorBuilder
 			.of(User.class)
 			.constraint(User::getName, "name",
@@ -41,7 +41,7 @@ public class BiValidatorTest {
 							new SimpleMessageFormatter(), Locale.ENGLISH)));
 
 	@Test
-	public void allValid() throws Exception {
+	void allValid() throws Exception {
 		User user = new User("Demo", "demo@example.com", 100);
 		user.setEnabled(true);
 		final List<ConstraintViolation> violations = new ArrayList<>();
@@ -51,7 +51,7 @@ public class BiValidatorTest {
 	}
 
 	@Test
-	public void allInvalid() throws Exception {
+	void allInvalid() throws Exception {
 		User user = new User("", "example.com", 300);
 		user.setEnabled(false);
 		final List<ConstraintViolation> violations = new ArrayList<>();

--- a/src/test/java/am/ik/yavi/core/CastTest.java
+++ b/src/test/java/am/ik/yavi/core/CastTest.java
@@ -15,15 +15,15 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class CastTest {
+class CastTest {
 	@Test
-	public void anotherClonedValidatorShouldAlsoWork_GH23() {
+	void anotherClonedValidatorShouldAlsoWork_GH23() {
 		final Student student = new Student();
 		final ConstraintViolations result = Student.validator.validate(student);
 		assertThat(result.isValid()).isFalse();
@@ -33,7 +33,7 @@ public class CastTest {
 	}
 
 	@Test
-	public void castShouldWork_GH23() {
+	void castShouldWork_GH23() {
 		final Employee employee = new Employee();
 		final ConstraintViolations result = Employee.validator.validate(employee);
 		assertThat(result.isValid()).isFalse();
@@ -43,7 +43,7 @@ public class CastTest {
 	}
 
 	@Test
-	public void originalValidatorShouldAlsoWork_GH23() {
+	void originalValidatorShouldAlsoWork_GH23() {
 		final Person person = new Person();
 		final ConstraintViolations result = Person.validator.validate(person);
 		assertThat(result.isValid()).isFalse();
@@ -51,53 +51,53 @@ public class CastTest {
 		assertThat(result.get(0).name()).isEqualTo("name");
 	}
 
-	public static class Employee extends Person {
-		public static final Validator<Employee> validator = Person.validatorBuilder
-				.clone().cast(Employee.class)
+	static class Employee extends Person {
+		static final Validator<Employee> validator = Person.validatorBuilder.clone()
+				.cast(Employee.class)
 				.constraint(Employee::getServiceId, "service", Constraint::notNull)
 				.build();
 
 		private String serviceId;
 
-		public String getServiceId() {
+		String getServiceId() {
 			return serviceId;
 		}
 
-		public void setServiceId(String serviceId) {
+		void setServiceId(String serviceId) {
 			this.serviceId = serviceId;
 		}
 	}
 
-	public static class Person {
+	static class Person {
 		static ValidatorBuilder<Person> validatorBuilder = ValidatorBuilder
 				.of(Person.class)
 				.constraint(Person::getName, "name", Constraint::notNull);
 
-		public static final Validator<Person> validator = validatorBuilder.build();
+		static final Validator<Person> validator = validatorBuilder.build();
 
 		private String name;
 
-		public String getName() {
+		String getName() {
 			return name;
 		}
 
-		public void setName(String name) {
+		void setName(String name) {
 			this.name = name;
 		}
 	}
 
-	public static class Student extends Person {
-		public static final Validator<Student> validator = Person.validatorBuilder.clone()
+	static class Student extends Person {
+		static final Validator<Student> validator = Person.validatorBuilder.clone()
 				.cast(Student.class).constraint(Student::getId, "id", Constraint::notNull)
 				.build();
 
 		private String id;
 
-		public String getId() {
+		String getId() {
 			return id;
 		}
 
-		public void setId(String id) {
+		void setId(String id) {
 			this.id = id;
 		}
 	}

--- a/src/test/java/am/ik/yavi/core/ConstraintGroupTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintGroupTest.java
@@ -15,21 +15,21 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConstraintGroupTest {
+class ConstraintGroupTest {
 
 	@Test
-	public void name() {
+	void name() {
 		ConstraintGroup cg = ConstraintGroup.of("foo");
 		assertThat(cg.name()).isEqualTo("foo");
 		assertThat(cg.name()).isNotEqualTo("Foo");
 	}
 
 	@Test
-	public void testEnum() {
+	void testEnum() {
 		ConstraintCondition<?> condition = CustomGroup.FOO.toCondition();
 		assertThat(condition.test(null, CustomGroup.FOO)).isTrue();
 		assertThat(condition.test(null, CustomGroup.BAR)).isFalse();
@@ -37,7 +37,7 @@ public class ConstraintGroupTest {
 	}
 
 	@Test
-	public void toCondition() {
+	void toCondition() {
 		ConstraintGroup cg = ConstraintGroup.of("foo");
 		ConstraintCondition<?> condition = cg.toCondition();
 		assertThat(condition.test(null, ConstraintGroup.of("foo"))).isTrue();

--- a/src/test/java/am/ik/yavi/core/CustomValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/CustomValidatorTest.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import am.ik.yavi.Book;
 import am.ik.yavi.Range;
 import am.ik.yavi.builder.ValidatorBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/am/ik/yavi/core/InlineArrayValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/InlineArrayValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,9 +25,9 @@ import am.ik.yavi.FormWithArray;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class InlineArrayValidatorTest extends AbstractArrayValidatorTest {
+class InlineArrayValidatorTest extends AbstractArrayValidatorTest {
 	@Test
-	public void nullCollectionValid() throws Exception {
+	void nullCollectionValid() throws Exception {
 		Validator<FormWithArray> validator = ValidatorBuilder.of(FormWithArray.class) //
 				.forEachIfPresent(FormWithArray::getAddresses, "addresses",
 						b -> b.constraint(Address::street, "street",

--- a/src/test/java/am/ik/yavi/core/InlineCollectionValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/InlineCollectionValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,9 +25,9 @@ import am.ik.yavi.FormWithCollection;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class InlineCollectionValidatorTest extends AbstractCollectionValidatorTest {
+class InlineCollectionValidatorTest extends AbstractCollectionValidatorTest {
 	@Test
-	public void nullCollectionValid() throws Exception {
+	void nullCollectionValid() throws Exception {
 		Validator<FormWithCollection> validator = ValidatorBuilder
 				.of(FormWithCollection.class) //
 				.forEachIfPresent(FormWithCollection::getAddresses, "addresses",

--- a/src/test/java/am/ik/yavi/core/InlineMapValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/InlineMapValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,9 +25,9 @@ import am.ik.yavi.FormWithMap;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class InlineMapValidatorTest extends AbstractMapValidatorTest {
+class InlineMapValidatorTest extends AbstractMapValidatorTest {
 	@Test
-	public void nullCollectionValid() throws Exception {
+	void nullCollectionValid() throws Exception {
 		Validator<FormWithMap> validator = ValidatorBuilder.of(FormWithMap.class) //
 				.forEachIfPresent(FormWithMap::getAddresses, "addresses",
 						b -> b.constraint(Address::street, "street",

--- a/src/test/java/am/ik/yavi/core/MapValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/MapValidatorTest.java
@@ -15,7 +15,7 @@
  */
 package am.ik.yavi.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +25,7 @@ import am.ik.yavi.FormWithMap;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class MapValidatorTest extends AbstractMapValidatorTest {
+class MapValidatorTest extends AbstractMapValidatorTest {
 	Validator<Address> addressValidator = ValidatorBuilder.<Address> of()
 			.constraint(Address::street, "street", c -> c.notBlank().lessThan(32))
 			.nest(Address::country, "country", Country.validator())
@@ -33,7 +33,7 @@ public class MapValidatorTest extends AbstractMapValidatorTest {
 			.build();
 
 	@Test
-	public void nullCollectionValid() throws Exception {
+	void nullCollectionValid() throws Exception {
 		Validator<FormWithMap> validator = ValidatorBuilder.of(FormWithMap.class) //
 				.forEachIfPresent(FormWithMap::getAddresses, "addresses",
 						addressValidator)

--- a/src/test/java/am/ik/yavi/core/MultiNestedCollectionValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/MultiNestedCollectionValidatorTest.java
@@ -17,7 +17,7 @@ package am.ik.yavi.core;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,7 +28,7 @@ import am.ik.yavi.NestedFormWithCollection;
 import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.builder.ValidatorBuilder;
 
-public class MultiNestedCollectionValidatorTest {
+class MultiNestedCollectionValidatorTest {
 	Validator<Address> addressValidator = ValidatorBuilder.<Address> of()
 			.constraint(Address::street, "street", c -> c.notBlank().lessThan(32))
 			.nest(Address::country, "country", Country.validator())
@@ -44,7 +44,7 @@ public class MultiNestedCollectionValidatorTest {
 			.forEach(NestedFormWithCollection::getForms, "forms", formValidator).build();
 
 	@Test
-	public void invalid() {
+	void invalid() {
 		NestedFormWithCollection form = new NestedFormWithCollection(
 				Arrays.asList(new FormWithCollection(Arrays.asList(
 						new Address(new Country("JP"), "tokyo",
@@ -64,7 +64,7 @@ public class MultiNestedCollectionValidatorTest {
 	}
 
 	@Test
-	public void valid() {
+	void valid() {
 		NestedFormWithCollection form = new NestedFormWithCollection(
 				Arrays.asList(new FormWithCollection(Arrays.asList(
 						new Address(new Country("JP"), "tokyo",

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -29,15 +29,15 @@ import am.ik.yavi.constraint.charsequence.CodePoints;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsRanges;
 import am.ik.yavi.constraint.charsequence.CodePoints.CodePointsSet;
 import am.ik.yavi.fn.Either;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static am.ik.yavi.constraint.charsequence.variant.IdeographicVariationSequence.IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class ValidatorTest {
+class ValidatorTest {
 	@Test
-	public void allInvalid() throws Exception {
+	void allInvalid() throws Exception {
 		User user = new User("", "example.com", 300);
 		user.setEnabled(false);
 		Validator<User> validator = validator();
@@ -59,7 +59,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsAllIncludedRange() throws Exception {
+	void codePointsAllIncludedRange() throws Exception {
 		CodePointsRanges<String> whiteList = () -> Arrays.asList(
 				CodePoints.Range.of(0x0041/* A */, 0x005A /* Z */),
 				CodePoints.Range.of(0x0061/* a */, 0x007A /* z */));
@@ -78,7 +78,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsAllIncludedRangeBeginToEnd() throws Exception {
+	void codePointsAllIncludedRangeBeginToEnd() throws Exception {
 		User user = new User("abc@b.c", null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -93,7 +93,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsAllIncludedRangeRange() throws Exception {
+	void codePointsAllIncludedRangeRange() throws Exception {
 		User user = new User("abc@b.c", null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class).constraint(
 				User::getName, "name",
@@ -109,7 +109,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsAllIncludedSet() throws Exception {
+	void codePointsAllIncludedSet() throws Exception {
 		CodePointsSet<String> whiteList = () -> new HashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
 						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
@@ -140,7 +140,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsAllIncludedSetSet() throws Exception {
+	void codePointsAllIncludedSetSet() throws Exception {
 		Set<Integer> whiteList = new HashSet<>(
 				Arrays.asList(0x0041 /* A */, 0x0042 /* B */, 0x0043 /* C */,
 						0x0044 /* D */, 0x0045 /* E */, 0x0046 /* F */, 0x0047 /* G */,
@@ -171,7 +171,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsNotIncludedRange() throws Exception {
+	void codePointsNotIncludedRange() throws Exception {
 		CodePointsRanges<String> blackList = () -> Arrays.asList(
 				CodePoints.Range.of(0x0041/* A */, 0x0042 /* B */),
 				CodePoints.Range.of(0x0061/* a */, 0x0062 /* b */));
@@ -190,7 +190,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void codePointsNotIncludedSet() throws Exception {
+	void codePointsNotIncludedSet() throws Exception {
 		CodePointsSet<String> blackList = () -> new HashSet<>(
 				Arrays.asList(0x0061 /* a */, 0x0062 /* b */));
 
@@ -208,7 +208,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void combiningCharacterByteSizeInValid() throws Exception {
+	void combiningCharacterByteSizeInValid() throws Exception {
 		User user = new User("モジ" /* モシ\u3099 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -222,7 +222,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void combiningCharacterSizeAndByteSizeInValid() throws Exception {
+	void combiningCharacterSizeAndByteSizeInValid() throws Exception {
 		User user = new User("モジ" /* モシ\u3099 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -238,7 +238,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void combiningCharacterValid() throws Exception {
+	void combiningCharacterValid() throws Exception {
 		User user = new User("モジ" /* モシ\u3099 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -249,7 +249,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void condition() {
+	void condition() {
 		Validator<User> validator = ValidatorBuilder.of(User.class) //
 				.constraintOnCondition((u, cg) -> !u.getName().isEmpty(), //
 						b -> b.constraint(User::getEmail, "email",
@@ -272,7 +272,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void constraintOnTarget() {
+	void constraintOnTarget() {
 		Validator<Range> validator = ValidatorBuilder.of(Range.class) //
 				.constraintOnTarget(Range::isToGreaterThanFrom, "to",
 						"to.isGreaterThanFrom", "\"to\" must be greater than \"from\".") //
@@ -294,7 +294,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void customMessageFormatter() throws Exception {
+	void customMessageFormatter() throws Exception {
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.messageFormatter((messageKey, defaultMessageFormat, args,
 						locale) -> args[0].toString().toUpperCase() + "."
@@ -312,7 +312,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void details() throws Exception {
+	void details() throws Exception {
 		User user = new User("", "example.com", 300);
 		Validator<User> validator = validator();
 		ConstraintViolations violations = validator.validate(user);
@@ -334,7 +334,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void emojiInValid() throws Exception {
+	void emojiInValid() throws Exception {
 		User user = new User("I❤️☕️", null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name", c -> c.emoji().greaterThan(3)).build();
@@ -347,7 +347,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void emojiValid() throws Exception {
+	void emojiValid() throws Exception {
 		User user = new User("I❤️☕️", null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name", c -> c.emoji().lessThanOrEqual(3))
@@ -357,7 +357,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void group() {
+	void group() {
 		User user = new User("foobar", "foo@example.com", -1);
 		Validator<User> validator = ValidatorBuilder.of(User.class) //
 				.constraintOnCondition(Group.UPDATE.toCondition(), //
@@ -380,7 +380,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void groupConditionByGroup() {
+	void groupConditionByGroup() {
 		User user = new User("foobar", "foo@example.com", -1);
 		Validator<User> validator = ValidatorBuilder.of(User.class) //
 				.constraintOnCondition(
@@ -413,7 +413,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void groupTwoCondition() {
+	void groupTwoCondition() {
 		User user = new User("foobar", "foo@example.com", -1);
 		Validator<User> validator = ValidatorBuilder.of(User.class) //
 				.constraintOnGroup(Group.UPDATE, //
@@ -443,7 +443,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ivsByteSizeInValid() throws Exception {
+	void ivsByteSizeInValid() throws Exception {
 		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -458,7 +458,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ivsInValid() throws Exception {
+	void ivsInValid() throws Exception {
 		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -472,7 +472,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ivsSizeAndByteSizeInValid() throws Exception {
+	void ivsSizeAndByteSizeInValid() throws Exception {
 		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -488,7 +488,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ivsValid() throws Exception {
+	void ivsValid() throws Exception {
 		User user = new User("葛󠄁飾区" /* 葛\uDB40\uDD01飾区 */, null, null);
 		Validator<User> validator = ValidatorBuilder.of(User.class)
 				.constraint(User::getName, "name",
@@ -501,7 +501,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void multipleViolationOnOneProperty() throws Exception {
+	void multipleViolationOnOneProperty() throws Exception {
 		User user = new User("foo", "aa", 200);
 		Validator<User> validator = validator();
 		ConstraintViolations violations = validator.validate(user);
@@ -517,7 +517,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void nullValues() throws Exception {
+	void nullValues() throws Exception {
 		User user = new User(null, null, null);
 		Validator<User> validator = validator();
 		ConstraintViolations violations = validator.validate(user);
@@ -532,7 +532,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void overrideMessage() {
+	void overrideMessage() {
 		Validator<User> validator = ValidatorBuilder.<User> of() //
 				.constraint(User::getName, "name",
 						c -> c.notNull().message("name is required!") //
@@ -569,7 +569,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void overrideViolationMessage() {
+	void overrideViolationMessage() {
 		Validator<User> validator = ValidatorBuilder.<User> of() //
 				.constraint(User::getName, "name",
 						c -> c.notNull()
@@ -607,7 +607,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void throwIfInValidInValid() throws Exception {
+	void throwIfInValidInValid() throws Exception {
 		User user = new User("foo", "foo@example.com", -1);
 		try {
 			validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
@@ -625,13 +625,13 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void throwIfInValidValid() throws Exception {
+	void throwIfInValidValid() throws Exception {
 		User user = new User("foo", "foo@example.com", 30);
 		validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);
 	}
 
 	@Test
-	public void valid() throws Exception {
+	void valid() throws Exception {
 		User user = new User("foo", "foo@example.com", 30);
 		Validator<User> validator = validator();
 		ConstraintViolations violations = validator.validate(user);
@@ -639,7 +639,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void validateToEitherInValid() throws Exception {
+	void validateToEitherInValid() throws Exception {
 		User user = new User("foo", "foo@example.com", -1);
 		Either<ConstraintViolations, User> either = validator().either().validate(user);
 		assertThat(either.isLeft()).isTrue();
@@ -653,7 +653,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void validateToEitherValid() throws Exception {
+	void validateToEitherValid() throws Exception {
 		User user = new User("foo", "foo@example.com", 30);
 		Either<ConstraintViolations, User> either = validator().either().validate(user);
 		assertThat(either.isRight()).isTrue();
@@ -661,7 +661,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void violateGroupAndDefault() {
+	void violateGroupAndDefault() {
 		User user = new User("foobar", "foo@example.com", -1);
 		Validator<User> validator = ValidatorBuilder.of(User.class) //
 				.constraint(User::getEmail, "email", c -> c.email().lessThanOrEqual(10))
@@ -694,7 +694,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void agePositiveValidatorUserValid() {
+	void agePositiveValidatorUserValid() {
 		User user = new User("Diego", "foo@bar.com", 10);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
@@ -705,7 +705,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void agePositiveValidatorUserInValid() {
+	void agePositiveValidatorUserInValid() {
 		User user = new User("Diego", "foo@bar.com", -1);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
@@ -718,7 +718,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ageNegativeValidatorUserValid() {
+	void ageNegativeValidatorUserValid() {
 		User user = new User("Diego", "foo@bar.com", -1);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()
@@ -729,7 +729,7 @@ public class ValidatorTest {
 	}
 
 	@Test
-	public void ageNegativeValidatorUserInValid() {
+	void ageNegativeValidatorUserInValid() {
 		User user = new User("Diego", "foo@bar.com", 10);
 
 		Validator<User> validator = ValidatorBuilder.<User> of()


### PR DESCRIPTION
There were old JUnit4 testcases that are now migrated to JUnit5. Additionally, the JUnit4 dependency is remove. JUnit 4 is only accessible through JUnit Vintage.

This is needed so we can fully take advantage of JUnit 5 in the future.
Advantages can be seen here: https://www.baeldung.com/junit-5-migration#junit-5-advantages