### PR TITLE
`LocalTime` temporal support.

### DIFF
--- a/src/main/java/am/ik/yavi/arguments/LocalTimeValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/LocalTimeValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.arguments;
+
+import am.ik.yavi.core.Validator;
+import am.ik.yavi.fn.Function1;
+
+import java.time.LocalTime;
+import java.util.function.Function;
+
+/**
+ * @since 0.10.0
+ */
+public class LocalTimeValidator<T> extends DefaultArguments1Validator<LocalTime, T> {
+
+	@Override
+	public <T2> LocalTimeValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+		return new LocalTimeValidator<>(super.validator,
+				s -> mapper.apply(super.mapper.apply(s)));
+	}
+
+	public LocalTimeValidator(Validator<Arguments1<LocalTime>> validator,
+			Function1<? super LocalTime, ? extends T> mapper) {
+		super(validator, mapper);
+	}
+}

--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -19,6 +19,7 @@ import am.ik.yavi.constraint.*;
 import am.ik.yavi.constraint.array.*;
 import am.ik.yavi.constraint.temporal.LocalDateConstraint;
 import am.ik.yavi.constraint.temporal.LocalDateTimeConstraint;
+import am.ik.yavi.constraint.temporal.LocalTimeConstraint;
 import am.ik.yavi.constraint.temporal.ZonedDateTimeConstraint;
 import am.ik.yavi.core.*;
 import am.ik.yavi.fn.Pair;
@@ -30,6 +31,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.Consumer;
@@ -139,6 +141,30 @@ public class ValidatorBuilder<T> implements Cloneable {
 	public <E> BiValidator<T, E> build(BiValidator.ErrorHandler<E> errorHandler) {
 		final Validator<T> validator = this.build();
 		return new BiValidator<>(validator, errorHandler);
+	}
+
+	/**
+	 * @since 0.10.0
+	 */
+	public ValidatorBuilder<T> constraint(ToLocalTimeConstraint<T> f, String name,
+			Function<LocalTimeConstraint<T>, LocalTimeConstraint<T>> c) {
+		return this.constraint(f, name, c, LocalTimeConstraint::new);
+	}
+
+	/**
+	 * @since 0.10.0
+	 */
+	public ValidatorBuilder<T> constraint(LocalTimeConstraintMeta<T> meta,
+			Function<LocalTimeConstraint<T>, LocalTimeConstraint<T>> c) {
+		return this.constraint(meta.toValue(), meta.name(), c, LocalTimeConstraint::new);
+	}
+
+	/**
+	 * @since 0.10.0
+	 */
+	public ValidatorBuilder<T> _localTime(ToLocalTimeConstraint<T> f, String name,
+			Function<LocalTimeConstraint<T>, LocalTimeConstraint<T>> c) {
+		return this.constraint(f, name, c, LocalTimeConstraint::new);
 	}
 
 	/**
@@ -889,6 +915,9 @@ public class ValidatorBuilder<T> implements Cloneable {
 			}
 			return Arrays.asList(array);
 		};
+	}
+
+	public interface ToLocalTimeConstraint<T> extends Function<T, LocalTime> {
 	}
 
 	public interface ToZonedDateTimeConstraint<T> extends Function<T, ZonedDateTime> {

--- a/src/main/java/am/ik/yavi/constraint/temporal/LocalTimeConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/temporal/LocalTimeConstraint.java
@@ -1,0 +1,89 @@
+package am.ik.yavi.constraint.temporal;
+
+import am.ik.yavi.core.ConstraintPredicate;
+
+import java.time.LocalTime;
+import java.util.function.Predicate;
+
+import static am.ik.yavi.core.NullAs.VALID;
+import static am.ik.yavi.core.ViolationMessage.Default.TEMPORAL_HOUR;
+import static am.ik.yavi.core.ViolationMessage.Default.TEMPORAL_MINUTE;
+
+/**
+ * This is the actual class for constraints on LocalTime.
+ *
+ * @author Diego Krupitza
+ */
+public class LocalTimeConstraint<T>
+		extends ComparableTemporalConstraintBase<T, LocalTime, LocalTimeConstraint<T>> {
+
+	/**
+	 * Is the given LocalTime at the same hour as {@code other}
+	 *
+	 * @param other the other localtime that wraps the hour
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> hour(LocalTime other) {
+		this.predicates().add(ConstraintPredicate.of(x -> x.getHour() == other.getHour(),
+				TEMPORAL_HOUR, () -> new Object[] { other.getHour() }, VALID));
+		return cast();
+	}
+
+	/**
+	 * Is the given LocalTime at the same hour as {@code hour}
+	 *
+	 * @param hour the hour the LocalTime should have
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> hour(Integer hour) {
+		if (hour < 0 || hour >= 23) {
+			throw new IllegalArgumentException(
+					"The parameter `hour` has to be between 0 and 23");
+		}
+		return this.hour(LocalTime.of(hour, 0));
+	}
+
+	/**
+	 * Is the given LocalTime at the same minute as {@code hour}
+	 *
+	 * @param minute the minute the LocalTime should have
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> minute(Integer minute) {
+		if (minute < 0 || minute >= 60) {
+			throw new IllegalArgumentException(
+					"The parameter `minute` has to be between 0 and 59");
+		}
+		return this.minute(LocalTime.of(1, minute));
+	}
+
+	/**
+	 * Is the given LocalTime at the same minute as {@code other}
+	 *
+	 * @param other the other localtime that wraps the minute
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> minute(LocalTime other) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.getMinute() == other.getMinute(),
+						TEMPORAL_MINUTE, () -> new Object[] { other.getMinute() },
+						VALID));
+		return cast();
+	}
+
+	@Override
+	protected Predicate<LocalTime> isBetween(LocalTime rangeFrom, LocalTime rangeTo) {
+		return x -> {
+			if (rangeFrom.isAfter(rangeTo)) {
+				throw new IllegalArgumentException(
+						"Parameter 'rangeFrom' has to be before 'rangeTo'");
+			}
+			return rangeFrom.isBefore(x) && rangeTo.isAfter(x);
+		};
+	}
+
+	@Override
+	public LocalTimeConstraint<T> cast() {
+		return this;
+	}
+}

--- a/src/main/java/am/ik/yavi/constraint/temporal/LocalTimeConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/temporal/LocalTimeConstraint.java
@@ -4,6 +4,7 @@ import am.ik.yavi.core.ConstraintPredicate;
 
 import java.time.LocalTime;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static am.ik.yavi.core.NullAs.VALID;
 import static am.ik.yavi.core.ViolationMessage.Default.TEMPORAL_HOUR;
@@ -20,13 +21,24 @@ public class LocalTimeConstraint<T>
 	/**
 	 * Is the given LocalTime at the same hour as {@code other}
 	 *
+	 * @param other the supplier that provides the other localtime that wraps the hour
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> hour(Supplier<LocalTime> other) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> x.getHour() == other.get().getHour(),
+						TEMPORAL_HOUR, () -> new Object[] { other.get() }, VALID));
+		return cast();
+	}
+
+	/**
+	 * Is the given LocalTime at the same hour as {@code other}
+	 *
 	 * @param other the other localtime that wraps the hour
 	 * @since 0.10.0
 	 */
 	public LocalTimeConstraint<T> hour(LocalTime other) {
-		this.predicates().add(ConstraintPredicate.of(x -> x.getHour() == other.getHour(),
-				TEMPORAL_HOUR, () -> new Object[] { other.getHour() }, VALID));
-		return cast();
+		return this.hour(() -> other);
 	}
 
 	/**
@@ -44,7 +56,22 @@ public class LocalTimeConstraint<T>
 	}
 
 	/**
-	 * Is the given LocalTime at the same minute as {@code hour}
+	 * Is the given LocalTime at the same minute as represented by the {@code quarter}
+	 * <ul>
+	 * <li>{@code quarter} = 0 -> XX:00</li>
+	 * <li>{@code quarter} = 1 -> XX:15</li>
+	 * <li>{@code quarter} = 2 -> XX:30</li>
+	 * </ul>
+	 *
+	 * @param quarter the quarter the LocalTime should have
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> quarter(Integer quarter) {
+		return this.minute(TemporalMinute.of(quarter));
+	}
+
+	/**
+	 * Is the given LocalTime at the same minute as {@code minute}
 	 *
 	 * @param minute the minute the LocalTime should have
 	 * @since 0.10.0
@@ -58,15 +85,35 @@ public class LocalTimeConstraint<T>
 	}
 
 	/**
+	 * Is the given LocalTime at the same minute as {@code hour}
+	 *
+	 * @param minute the minute the LocalTime should have
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> minute(TemporalMinute minute) {
+		return this.minute(LocalTime.of(1, minute.value()));
+	}
+
+	/**
 	 * Is the given LocalTime at the same minute as {@code other}
 	 *
 	 * @param other the other localtime that wraps the minute
 	 * @since 0.10.0
 	 */
 	public LocalTimeConstraint<T> minute(LocalTime other) {
+		return this.minute(() -> other);
+	}
+
+	/**
+	 * Is the given LocalTime at the same minute as {@code other}
+	 *
+	 * @param other the supplier that provides the other localtime that wraps the minute
+	 * @since 0.10.0
+	 */
+	public LocalTimeConstraint<T> minute(Supplier<LocalTime> other) {
 		this.predicates()
-				.add(ConstraintPredicate.of(x -> x.getMinute() == other.getMinute(),
-						TEMPORAL_MINUTE, () -> new Object[] { other.getMinute() },
+				.add(ConstraintPredicate.of(x -> x.getMinute() == other.get().getMinute(),
+						TEMPORAL_MINUTE, () -> new Object[] { other.get().getMinute() },
 						VALID));
 		return cast();
 	}

--- a/src/main/java/am/ik/yavi/constraint/temporal/TemporalMinute.java
+++ b/src/main/java/am/ik/yavi/constraint/temporal/TemporalMinute.java
@@ -1,0 +1,52 @@
+package am.ik.yavi.constraint.temporal;
+
+import java.util.stream.Stream;
+
+/**
+ * An enum that represents all the important minute values. This enum will allow you to
+ * have a more fluent way to specifying a given minute in validation. The following
+ * minutes are stored.
+ * <ul>
+ * <li>{@link TemporalMinute#FULL_HOUR} - the full hour</li>
+ * <li>{@link TemporalMinute#QUARTER_PAST} - 15 minutes</li>
+ * <li>{@link TemporalMinute#HALF_PAST} - 30 minutes</li>
+ * <li>{@link TemporalMinute#QUARTER_TO} - 45 minutes</li>
+ * </ul>
+ *
+ * @author Diego Krupitza
+ * @since 0.10.0
+ */
+public enum TemporalMinute {
+	FULL_HOUR(0), QUARTER_PAST(15), HALF_PAST(30), QUARTER_TO(45);
+
+	private final Integer minute;
+
+	TemporalMinute(Integer minute) {
+		this.minute = minute;
+	}
+
+	/**
+	 * @return the integer value representing the temporal minute
+	 * @since 0.10.0
+	 */
+	public Integer value() {
+		return minute;
+	}
+
+	/**
+	 * Gets the enum representing the given quarter of the hour. The {@code quarter} has
+	 * to be between 0 and 3.
+	 *
+	 * @param quarter the quarter of the {@link TemporalMinute} we want to receive
+	 * @return the {@link TemporalMinute} of the given quarter
+	 * @throws IllegalArgumentException in case the quarter is not between 0 and 3
+	 * @since 0.10.0
+	 */
+	public static TemporalMinute of(Integer quarter) {
+		return Stream.of(TemporalMinute.values())
+				.filter(item -> item.value().equals(quarter * 15)).findFirst()
+				.orElseThrow(() -> new IllegalArgumentException(String.format(
+						"Please specify a quarter from 0 and 3! The quarter you provided %d is not valid!",
+						quarter)));
+	}
+}

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -121,7 +121,9 @@ public interface ViolationMessage {
 				"\"{0}\" must meet at least {1} policies from {2}"), //
 		TEMPORAL_BEFORE("temporal.before", "\"{0}\" has to be before {1}"), //
 		TEMPORAL_AFTER("temporal.after", "\"{0}\" has to be after {1}"), //
-		TEMPORAL_BETWEEN("temporal.between", "\"{0}\" has to be between {1} and {2}") //
+		TEMPORAL_BETWEEN("temporal.between", "\"{0}\" has to be between {1} and {2}"), //
+		TEMPORAL_HOUR("temporal.hour", "\"{0}\" must have the hour {1}"), //
+		TEMPORAL_MINUTE("temporal.minute", "\"{0}\" must have the minute {1}") //
 		;
 
 		private final String defaultMessageFormat;

--- a/src/main/java/am/ik/yavi/meta/LocalTimeConstraintMeta.java
+++ b/src/main/java/am/ik/yavi/meta/LocalTimeConstraintMeta.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018-2021 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.yavi.meta;
+
+import java.time.LocalTime;
+
+public interface LocalTimeConstraintMeta<T> extends ConstraintMeta<T, LocalTime> {
+
+}

--- a/src/test/java/am/ik/yavi/CalendarEntryLocalTime.java
+++ b/src/test/java/am/ik/yavi/CalendarEntryLocalTime.java
@@ -1,0 +1,29 @@
+package am.ik.yavi;
+
+import java.time.LocalTime;
+
+public class CalendarEntryLocalTime {
+	private String title;
+	private LocalTime time;
+
+	public CalendarEntryLocalTime(String title, LocalTime timepoint) {
+		this.title = title;
+		this.time = timepoint;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public LocalTime getTime() {
+		return time;
+	}
+
+	public void setTime(LocalTime time) {
+		this.time = time;
+	}
+}

--- a/src/test/java/am/ik/yavi/constraint/temporal/LocalTimeConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/temporal/LocalTimeConstraintTest.java
@@ -1,0 +1,217 @@
+package am.ik.yavi.constraint.temporal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalTime;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalTimeConstraintTest {
+
+	private static final LocalTime BASE_TIME = LocalTime.of(12, 30);
+
+	@Test
+	void isBeforeValid() {
+		LocalTime future = BASE_TIME.plusHours(10);
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.before(future));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void isBeforeInValid() {
+		LocalTime past = BASE_TIME.minusHours(10);
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.before(past));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isBeforeSupplierValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.before(() -> BASE_TIME.plusHours(10)));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void isBeforeSupplierInValid() {
+		LocalTime past = BASE_TIME.minusHours(10);
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.before(() -> past));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isAfterInValid() {
+		LocalTime future = BASE_TIME.plusHours(10);
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.after(future));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isAfterValid() {
+		LocalTime past = BASE_TIME.minusHours(10);
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.after(past));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void isAfterSupplierInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.after(() -> BASE_TIME.plusHours(10)));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isAfterSupplierValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.after(() -> BASE_TIME.minusHours(10)));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@ParameterizedTest
+	@MethodSource("validBetweenDates")
+	void isBetweenValid(LocalTime BASE_TIME, LocalTime rangeFrom, LocalTime rangeTo) {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.between(rangeFrom, rangeTo));
+		assertThat(predicate.test(LocalTimeConstraintTest.BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void isBetweenExactInValid() {
+
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.between(BASE_TIME, BASE_TIME));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isBetweenInValidException() {
+		LocalTime rangeTo = BASE_TIME.minusHours(1);
+		LocalTime rangeFrom = BASE_TIME.plusHours(1);
+
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.between(rangeFrom, rangeTo));
+		assertThatThrownBy(() -> predicate.test(BASE_TIME))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Parameter 'rangeFrom' has to be before 'rangeTo'");
+	}
+
+	@ParameterizedTest
+	@MethodSource("validBetweenDates")
+	void isBetweenSupplierValid(LocalTime now, LocalTime rangeFrom, LocalTime rangeTo) {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.between(() -> rangeFrom, () -> rangeTo));
+		assertThat(predicate.test(now)).isTrue();
+	}
+
+	@Test
+	void isBetweenSupplierExactInValid() {
+		Supplier<LocalTime> nowSupplier = () -> BASE_TIME;
+
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.between(nowSupplier, nowSupplier));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void isBetweenSupplierInValidException() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c
+				.between(() -> BASE_TIME.plusHours(1), () -> BASE_TIME.minusHours(1)));
+		assertThatThrownBy(() -> predicate.test(BASE_TIME))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Parameter 'rangeFrom' has to be before 'rangeTo'");
+	}
+
+	@Test
+	void hourIntegerValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.hour(BASE_TIME.getHour()));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void hourLocalTimeValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.hour(BASE_TIME));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void hourIntegerInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.hour(1));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void hourIntegerInValidException() {
+		assertThatThrownBy(() -> retrievePredicate(c -> c.hour(-1)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("hour");
+
+		assertThatThrownBy(() -> retrievePredicate(c -> c.hour(24)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("hour");
+	}
+
+	@Test
+	void hourLocalTimeInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.hour(LocalTime.of(1, 0)));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void minuteIntegerValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.minute(BASE_TIME.getMinute()));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void minuteLocalTimeValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.minute(BASE_TIME));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void minuteIntegerInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.minute(1));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void minuteIntegerInValidException() {
+		assertThatThrownBy(() -> retrievePredicate(c -> c.minute(-1)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("minute");
+
+		assertThatThrownBy(() -> retrievePredicate(c -> c.minute(60)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("minute");
+	}
+
+	@Test
+	void minuteLocalTimeInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.minute(LocalTime.of(12, 1)));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	private static Stream<Arguments> validBetweenDates() {
+		return IntStream.rangeClosed(1, 10).boxed().map(i -> Arguments.of(BASE_TIME,
+				BASE_TIME.minusHours(i), BASE_TIME.plusHours(i)));
+	}
+
+	private static Predicate<LocalTime> retrievePredicate(
+			Function<LocalTimeConstraint<LocalTime>, LocalTimeConstraint<LocalTime>> constraint) {
+		return constraint.apply(new LocalTimeConstraint<>()).predicates().peekFirst()
+				.predicate();
+	}
+
+}

--- a/src/test/java/am/ik/yavi/constraint/temporal/LocalTimeConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/temporal/LocalTimeConstraintTest.java
@@ -149,6 +149,12 @@ class LocalTimeConstraintTest {
 	}
 
 	@Test
+	void hourSupplierLocalTimeValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.hour(() -> BASE_TIME));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
 	void hourIntegerInValidException() {
 		assertThatThrownBy(() -> retrievePredicate(c -> c.hour(-1)))
 				.isInstanceOf(IllegalArgumentException.class)
@@ -174,6 +180,25 @@ class LocalTimeConstraintTest {
 	}
 
 	@Test
+	void minuteTemporalMinuteValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.minute(TemporalMinute.HALF_PAST));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void minuteQuartalValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.quarter(2));
+		assertThat(predicate.test(BASE_TIME)).isTrue();
+	}
+
+	@Test
+	void minuteQuartalInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(c -> c.quarter(3));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
 	void minuteLocalTimeValid() {
 		Predicate<LocalTime> predicate = retrievePredicate(c -> c.minute(BASE_TIME));
 		assertThat(predicate.test(BASE_TIME)).isTrue();
@@ -182,6 +207,13 @@ class LocalTimeConstraintTest {
 	@Test
 	void minuteIntegerInValid() {
 		Predicate<LocalTime> predicate = retrievePredicate(c -> c.minute(1));
+		assertThat(predicate.test(BASE_TIME)).isFalse();
+	}
+
+	@Test
+	void minuteTemporalMinuteInValid() {
+		Predicate<LocalTime> predicate = retrievePredicate(
+				c -> c.minute(TemporalMinute.QUARTER_PAST));
 		assertThat(predicate.test(BASE_TIME)).isFalse();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/temporal/TemporalMinuteTest.java
+++ b/src/test/java/am/ik/yavi/constraint/temporal/TemporalMinuteTest.java
@@ -1,0 +1,38 @@
+package am.ik.yavi.constraint.temporal;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TemporalMinuteTest {
+
+	@ParameterizedTest
+	@MethodSource("validTemporalOfValues")
+	void validTemporalOfMatchesTest(Integer value, TemporalMinute expected) {
+		assertThat(TemporalMinute.of(value)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidTemporalOfValues")
+	void invalidValuesThrowException(Integer value) {
+		assertThatThrownBy(() -> TemporalMinute.of(value))
+				.isInstanceOf(IllegalArgumentException.class).hasMessageContaining(
+						"Please specify a quarter from 0 and 3! The quarter you provided "
+								+ value + " is not valid");
+	}
+
+	private static Stream<Arguments> validTemporalOfValues() {
+		return Stream.of(TemporalMinute.values())
+				.map(item -> Arguments.of(item.value() / 15, item));
+	}
+
+	private static Stream<Arguments> invalidTemporalOfValues() {
+		return IntStream.rangeClosed(4, 10).boxed().map(Arguments::of);
+	}
+}

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -15,10 +15,8 @@
  */
 package am.ik.yavi.core;
 
-import am.ik.yavi.CalendarEntryLocalDateTime;
+import am.ik.yavi.*;
 import am.ik.yavi.ConstraintViolationsException;
-import am.ik.yavi.Range;
-import am.ik.yavi.User;
 import am.ik.yavi.builder.ValidatorBuilder;
 import am.ik.yavi.constraint.base.NumericConstraintBase;
 import am.ik.yavi.constraint.charsequence.CodePoints;
@@ -28,6 +26,7 @@ import am.ik.yavi.fn.Either;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -922,6 +921,192 @@ class ValidatorTest {
 		assertThat(violations.size()).isEqualTo(1);
 		assertThat(violations.get(0).message())
 				.isEqualTo("\"name\" must end with \"Diego\"");
+	}
+
+	@Test
+	void timeIsBeforeNowValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.before(now.plusHours(10)))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	void timeIsBeforeNowInValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.before(now.minusHours(10)))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).startsWith("\"time\" has to be before");
+	}
+
+	@Test
+	void timeIsAfterNowInValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.after(now.plusHours(10)))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).startsWith("\"time\" has to be after");
+	}
+
+	@Test
+	void timeIsAfterNowValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.after(now.minusHours(10)))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	void timeIsBetweenNowValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		LocalTime before = now.minusHours(10);
+		LocalTime after = now.plusHours(10);
+
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.between(before, after))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	void timeIsBetweenNowEqualInValid() {
+		LocalTime now = LocalTime.of(12, 30);
+
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.between(now, now))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).startsWith("\"time\" has to be between");
+	}
+
+	@Test
+	void timeIsBetweenNowInValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		LocalTime before = now.plusHours(10);
+		LocalTime after = now.plusHours(10).plusMinutes(1);
+
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of().constraint(CalendarEntryLocalTime::getTime,
+						"time", c -> c.between(before, after))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message()).startsWith("\"time\" has to be between");
+	}
+
+	@Test
+	void timeHasHour12Valid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of()
+				.constraint(CalendarEntryLocalTime::getTime, "time", c -> c.hour(12))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	void timeHasMinute30Valid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of()
+				.constraint(CalendarEntryLocalTime::getTime, "time", c -> c.minute(30))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isTrue();
+	}
+
+	@Test
+	void timeHasHour12InValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of()
+				.constraint(CalendarEntryLocalTime::getTime, "time", c -> c.hour(13))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.startsWith("\"time\" must have the hour 13");
+	}
+
+	@Test
+	void timeHasMinute30InValid() {
+		LocalTime now = LocalTime.of(12, 30);
+		CalendarEntryLocalTime birthdayPartyEntry = new CalendarEntryLocalTime(
+				"BirthdayParty", now);
+
+		Validator<CalendarEntryLocalTime> validator = ValidatorBuilder
+				.<CalendarEntryLocalTime> of()
+				.constraint(CalendarEntryLocalTime::getTime, "time", c -> c.minute(31))
+				.build();
+
+		ConstraintViolations violations = validator.validate(birthdayPartyEntry);
+		assertThat(violations.isValid()).isFalse();
+		assertThat(violations.size()).isEqualTo(1);
+		assertThat(violations.get(0).message())
+				.startsWith("\"time\" must have the minute 31");
 	}
 
 	Validator<User> validator() {


### PR DESCRIPTION
It is now possible to have constraints on `LocalTime`. All the default constraints inherited from `ComparableTemporalConstraintBase` are available. Furthermore, you can validate the hour with `hour(...)` and the minute with `minute(...)`.

Related tickets #197