### PR TITLE
Added overloaded andThen method to chain ValueValidators

### DIFF
--- a/scripts/generate-args.sh
+++ b/scripts/generate-args.sh
@@ -200,6 +200,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 EOD
 fi)
@@ -283,6 +284,15 @@ fi)
 	default <X2> ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), X2> andThen(Function<? super X, ? extends X2> mapper) {
 		return (${as}, locale, constraintGroup) -> ${class}.this
 				.validate(${as}, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */$(if [ "${i}" == "1" ];then echo;echo "	@Override"; fi)
+	default <X2> ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), X2> andThen(ValueValidator<? super X, X2> validator) {
+		return (${as}, locale, constraintGroup) -> ${class}.this
+				.validate(${as}, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,18 @@ public interface Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X
 		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, locale,
 				constraintGroup) -> Arguments10Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, a10, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, locale,
+				constraintGroup) -> Arguments10Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, locale,
+								constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,18 @@ public interface Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, locale,
 				constraintGroup) -> Arguments11Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, a10, a11, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, locale,
+				constraintGroup) -> Arguments11Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, locale,
+								constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -46,6 +47,18 @@ public interface Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 				constraintGroup) -> Arguments12Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, a10, a11, a12, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, locale,
+				constraintGroup) -> Arguments12Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
+								locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -47,6 +48,18 @@ public interface Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 				constraintGroup) -> Arguments13Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, a10, a11, a12, a13, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, locale,
+				constraintGroup) -> Arguments13Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+								locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -47,6 +48,18 @@ public interface Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 				constraintGroup) -> Arguments14Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, a10, a11, a12, a13, a14, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, locale,
+				constraintGroup) -> Arguments14Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+								a14, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -48,6 +49,18 @@ public interface Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
 								a14, a15, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, locale,
+				constraintGroup) -> Arguments15Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+								a14, a15, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -48,6 +49,18 @@ public interface Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
 								a14, a15, a16, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16,
+				locale, constraintGroup) -> Arguments16Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
+								a14, a15, a16, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
@@ -78,6 +78,17 @@ public interface Arguments1Validator<A1, X> extends ValueValidator<A1, X> {
 	}
 
 	/**
+	 * @since 0.11.0
+	 */
+	@Override
+	default <X2> Arguments1Validator<A1, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, locale, constraintGroup) -> Arguments1Validator.this
+				.validate(a1, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
+	}
+
+	/**
 	 * @since 0.7.0
 	 */
 	@Override

--- a/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -42,6 +43,16 @@ public interface Arguments2Validator<A1, A2, X> {
 			Function<? super X, ? extends X2> mapper) {
 		return (a1, a2, locale, constraintGroup) -> Arguments2Validator.this
 				.validate(a1, a2, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments2Validator<A1, A2, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, locale, constraintGroup) -> Arguments2Validator.this
+				.validate(a1, a2, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -42,6 +43,16 @@ public interface Arguments3Validator<A1, A2, A3, X> {
 			Function<? super X, ? extends X2> mapper) {
 		return (a1, a2, a3, locale, constraintGroup) -> Arguments3Validator.this
 				.validate(a1, a2, a3, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments3Validator<A1, A2, A3, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, locale, constraintGroup) -> Arguments3Validator.this
+				.validate(a1, a2, a3, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -42,6 +43,16 @@ public interface Arguments4Validator<A1, A2, A3, A4, X> {
 			Function<? super X, ? extends X2> mapper) {
 		return (a1, a2, a3, a4, locale, constraintGroup) -> Arguments4Validator.this
 				.validate(a1, a2, a3, a4, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments4Validator<A1, A2, A3, A4, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, locale, constraintGroup) -> Arguments4Validator.this
+				.validate(a1, a2, a3, a4, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -43,6 +44,16 @@ public interface Arguments5Validator<A1, A2, A3, A4, A5, X> {
 			Function<? super X, ? extends X2> mapper) {
 		return (a1, a2, a3, a4, a5, locale, constraintGroup) -> Arguments5Validator.this
 				.validate(a1, a2, a3, a4, a5, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments5Validator<A1, A2, A3, A4, A5, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, locale, constraintGroup) -> Arguments5Validator.this
+				.validate(a1, a2, a3, a4, a5, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,17 @@ public interface Arguments6Validator<A1, A2, A3, A4, A5, A6, X> {
 				constraintGroup) -> Arguments6Validator.this
 						.validate(a1, a2, a3, a4, a5, a6, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments6Validator<A1, A2, A3, A4, A5, A6, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, locale,
+				constraintGroup) -> Arguments6Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,17 @@ public interface Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X> {
 				constraintGroup) -> Arguments7Validator.this
 						.validate(a1, a2, a3, a4, a5, a6, a7, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, locale,
+				constraintGroup) -> Arguments7Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,17 @@ public interface Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X> {
 				constraintGroup) -> Arguments8Validator.this
 						.validate(a1, a2, a3, a4, a5, a6, a7, a8, locale, constraintGroup)
 						.map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, locale,
+				constraintGroup) -> Arguments8Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, locale, constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import am.ik.yavi.core.ConstraintGroup;
 import am.ik.yavi.core.ConstraintViolationsException;
 import am.ik.yavi.core.Validated;
+import am.ik.yavi.core.ValueValidator;
 import am.ik.yavi.jsr305.Nullable;
 
 /**
@@ -45,6 +46,18 @@ public interface Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X> {
 		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, locale,
 				constraintGroup) -> Arguments9Validator.this.validate(a1, a2, a3, a4, a5,
 						a6, a7, a8, a9, locale, constraintGroup).map(mapper);
+	}
+
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X2> andThen(
+			ValueValidator<? super X, X2> validator) {
+		return (a1, a2, a3, a4, a5, a6, a7, a8, a9, locale,
+				constraintGroup) -> Arguments9Validator.this
+						.validate(a1, a2, a3, a4, a5, a6, a7, a8, a9, locale,
+								constraintGroup)
+						.flatMap(v -> validator.validate(v, locale, constraintGroup));
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/core/ValueValidator.java
+++ b/src/main/java/am/ik/yavi/core/ValueValidator.java
@@ -50,6 +50,15 @@ public interface ValueValidator<T, X> {
 				.validate(t, locale, constraintGroup).map(mapper);
 	}
 
+	/**
+	 * @since 0.11.0
+	 */
+	default <X2> ValueValidator<T, X2> andThen(ValueValidator<? super X, X2> validator) {
+		return (t, locale, constraintGroup) -> ValueValidator.this
+				.validate(t, locale, constraintGroup)
+				.flatMap(v -> validator.validate(v, locale, constraintGroup));
+	}
+
 	default <A> ValueValidator<A, X> compose(Function<? super A, ? extends T> mapper) {
 		return (a, locale, constraintGroup) -> ValueValidator.this
 				.validate(mapper.apply(a), locale, constraintGroup);

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -38,26 +38,39 @@ class ValueValidatorTest {
 
 	@Test
 	void andThenChainsValidators() {
-		ValueValidator<String, Country> countryValidator = Country.validator().applicative().compose(Country::new);
+		ValueValidator<String, Country> countryValidator = Country.validator()
+				.applicative().compose(Country::new);
 		ValueValidator<String, String> streetValidator = ValueValidator.passThrough();
-		ValueValidator<String, PhoneNumber> phoneValidator = PhoneNumber.validator().applicative().compose(PhoneNumber::new);
+		ValueValidator<String, PhoneNumber> phoneValidator = PhoneNumber.validator()
+				.applicative().compose(PhoneNumber::new);
 
-		Arguments3Validator<String, String, String, Address> addressValidator = Arguments1Validator.from(countryValidator)
-				.split(streetValidator)
-				.split(phoneValidator)
+		Arguments3Validator<String, String, String, Address> addressValidator = Arguments1Validator
+				.from(countryValidator).split(streetValidator).split(phoneValidator)
 				.apply(Address::new);
 
-		ValueValidator<Address, Address> foreignAddressValidator = ValidatorBuilder.<Address>of()
+		ValueValidator<Address, Address> foreignAddressValidator = ValidatorBuilder
+				.<Address> of()
 				.constraintOnCondition(
-						(address, group) -> !"JP".equalsIgnoreCase(address.country().name()),
-						ValidatorBuilder.<Address>of()._string(a -> a.phoneNumber().value(), "PhoneNumber", c -> c.startsWith("+")).build())
+						(address,
+								group) -> !"JP"
+										.equalsIgnoreCase(address.country().name()),
+						ValidatorBuilder.<Address> of()
+								._string(a -> a.phoneNumber().value(), "PhoneNumber",
+										c -> c.startsWith("+"))
+								.build())
 				.build().applicative();
 
-		assertThat(addressValidator.validate("JP", "tokyo", "0123456789").isValid()).isTrue();
-		assertThat(addressValidator.andThen(foreignAddressValidator).validate("JP", "tokyo", "0123456789").isValid()).isTrue();
-		assertThat(addressValidator.validate("BE", "brussels", "9876543210").isValid()).isTrue();
-		assertThat(addressValidator.andThen(foreignAddressValidator).validate("BE", "brussels", "9876543210").isValid()).isFalse();
-		assertThat(addressValidator.validate("J", "tokyo", "0123456789").isValid()).isFalse();
-		assertThat(addressValidator.andThen(foreignAddressValidator).validate("J", "tokyo", "+0123456789").isValid()).isFalse();
+		assertThat(addressValidator.validate("JP", "tokyo", "0123456789").isValid())
+				.isTrue();
+		assertThat(addressValidator.andThen(foreignAddressValidator)
+				.validate("JP", "tokyo", "0123456789").isValid()).isTrue();
+		assertThat(addressValidator.validate("BE", "brussels", "9876543210").isValid())
+				.isTrue();
+		assertThat(addressValidator.andThen(foreignAddressValidator)
+				.validate("BE", "brussels", "9876543210").isValid()).isFalse();
+		assertThat(addressValidator.validate("J", "tokyo", "0123456789").isValid())
+				.isFalse();
+		assertThat(addressValidator.andThen(foreignAddressValidator)
+				.validate("J", "tokyo", "+0123456789").isValid()).isFalse();
 	}
 }


### PR DESCRIPTION
We need to validate the incoming data in multiple stages.

During a first stage, we check the provided input to be valid in order to create the different value objects.
Once those value objects could be constructed from the input, we apply a next stage of validations, which are targeted at the created value objects instead of the original input. 
When the first stage validations already fail, the second validations are not initiated.

For example, I have added a test in this PR that illustrates our use case:
In order to create an Address, we need a valid Country, Street (as plain String) and PhoneNumber.
First I validate the incoming strings using the validators that already existed.
When an Address could be created, I need additional validations on the created value objects, but not on the original input strings. For example, a phone number should start with a '+' when the country is not Japan.

I am aware I can accomplish something similar with _Validation.flatMap_, but this makes it more cumbersome to create a single validator method of constant for an entity of value object.

If there are any existing alternatives in the API (other than this PR that is), can you please give a pointer how to use it and I am happy to try it out. Thanks.