### PR TITLE
Fixed failing CI #597: Bump formatter-maven-plugin from 2.17.1 to 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.17.1</version>
+                <version>2.18.0</version>
                 <configuration>
                     <configFile>${project.basedir}/src/etc/eclipse-code-formatter.xml</configFile>
                     <encoding>UTF-8</encoding>

--- a/src/main/java/am/ik/yavi/core/BiValidator.java
+++ b/src/main/java/am/ik/yavi/core/BiValidator.java
@@ -25,7 +25,7 @@ import java.util.function.BiConsumer;
  * as Spring Framework's <code>org.springframework.validation.Validator</code>.
  *
  * Validator can be wrapped as follows:
- * 
+ *
  * <pre>
  * Validator&lt;CartItem&gt; validator = ValidatorBuilder.&lt;CartItem&gt; of()
  *                        .constraint(CartItem::getQuantity, "quantity", c -> c.greaterThan(0))

--- a/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/BiValidatorFactory.java
@@ -38,7 +38,7 @@ import am.ik.yavi.message.MessageFormatter;
  * </pre>
  *
  * A component can create a validator like following:
- * 
+ *
  * <pre>
  *{@literal @RestController}
  * public class OrderController {

--- a/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
+++ b/src/main/java/am/ik/yavi/factory/ValidatorFactory.java
@@ -37,7 +37,7 @@ import am.ik.yavi.message.MessageFormatter;
  * </pre>
  *
  * A component can create a validator like following:
- * 
+ *
  * <pre>
  *{@literal @RestController}
  * public class OrderController {


### PR DESCRIPTION
Manual fix for failed automatic version bump:
https://github.com/making/yavi/actions/runs/1918412073