### PR TITLE
Add `Pattern` and `Supplier<Pattern>` variants

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.regex.Pattern;
 
@@ -259,6 +260,26 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	public CharSequenceConstraint<T, E> pattern(String regex) {
 		this.predicates().add(ConstraintPredicate.of(x -> Pattern.matches(regex, x),
 				CHAR_SEQUENCE_PATTERN, () -> new Object[] { regex }, VALID));
+		return this;
+	}
+
+	/**
+	 * @since 0.11.1
+	 */
+	public CharSequenceConstraint<T, E> pattern(Pattern regex) {
+		this.predicates().add(ConstraintPredicate.of(x -> regex.matcher(x).matches(),
+				CHAR_SEQUENCE_PATTERN, () -> new Object[] { regex.pattern() }, VALID));
+		return this;
+	}
+
+	/**
+	 * @since 0.11.1
+	 */
+	public CharSequenceConstraint<T, E> pattern(Supplier<Pattern> regexSupplier) {
+		this.predicates()
+				.add(ConstraintPredicate.of(x -> regexSupplier.get().matcher(x).matches(),
+						CHAR_SEQUENCE_PATTERN,
+						() -> new Object[] { regexSupplier.get().pattern() }, VALID));
 		return this;
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -215,6 +216,38 @@ class CharSequenceConstraintTest {
 	@ValueSource(strings = { "134a", "abcd" })
 	void invalidPattern(String value) {
 		Predicate<String> predicate = retrievePredicate(c -> c.pattern("[0-9]{4}"));
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "1234", "0000" })
+	void validPattern_pattern(String value) {
+		final Pattern pattern = Pattern.compile("[0-9]{4}");
+		Predicate<String> predicate = retrievePredicate(c -> c.pattern(pattern));
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "134a", "abcd" })
+	void invalidPattern_pattern(String value) {
+		final Pattern pattern = Pattern.compile("[0-9]{4}");
+		Predicate<String> predicate = retrievePredicate(c -> c.pattern(pattern));
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "1234", "0000" })
+	void validPattern_patternSupplier(String value) {
+		Predicate<String> predicate = retrievePredicate(
+				c -> c.pattern((() -> Pattern.compile("[0-9]{4}"))));
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "134a", "abcd" })
+	void invalidPattern_patternSupplier(String value) {
+		Predicate<String> predicate = retrievePredicate(
+				c -> c.pattern(() -> Pattern.compile("[0-9]{4}")));
 		assertThat(predicate.test(value)).isFalse();
 	}
 


### PR DESCRIPTION
to `CharSequenceConstraint.pattern`
closes gh-232