### PR TITLE
Fix typo: negaitve -> negative

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -79,6 +79,17 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 	}
 
 	/**
+	 * @deprecated in favour of {@link NumericConstraintBase#negativeOrZero}
+	 * @since 0.10.0
+	 */
+	@Deprecated
+	public C negaitveOrZero() {
+		this.predicates().add(ConstraintPredicate.of(this.isLessThanOrEqual(zeroValue()),
+				NUMERIC_NEGATIVE_OR_ZERO, () -> new Object[] {}, VALID));
+		return cast();
+	}
+
+	/**
 	 * @since 0.10.0
 	 */
 	public C negativeOrZero() {

--- a/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
+++ b/src/main/java/am/ik/yavi/constraint/base/NumericConstraintBase.java
@@ -81,7 +81,7 @@ public abstract class NumericConstraintBase<T, V, C extends Constraint<T, V, C>>
 	/**
 	 * @since 0.10.0
 	 */
-	public C negaitveOrZero() {
+	public C negativeOrZero() {
 		this.predicates().add(ConstraintPredicate.of(this.isLessThanOrEqual(zeroValue()),
 				NUMERIC_NEGATIVE_OR_ZERO, () -> new Object[] {}, VALID));
 		return cast();

--- a/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
@@ -141,6 +141,22 @@ class BigDecimalConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "99", "100" })
+	void invalidNegaitveOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void validNegaitveOrZero(BigDecimal value) {
+		Predicate<BigDecimal> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(BigDecimal value) {
 		Predicate<BigDecimal> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigDecimalConstraintTest.java
@@ -143,7 +143,7 @@ class BigDecimalConstraintTest {
 	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(BigDecimal value) {
 		Predicate<BigDecimal> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -151,7 +151,7 @@ class BigDecimalConstraintTest {
 	@ValueSource(strings = { "-101", "-150", "0" })
 	void validNegativeOrZero(BigDecimal value) {
 		Predicate<BigDecimal> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
@@ -144,7 +144,7 @@ class BigIntegerConstraintTest {
 	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(BigInteger value) {
 		Predicate<BigInteger> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -152,7 +152,7 @@ class BigIntegerConstraintTest {
 	@ValueSource(strings = { "-101", "-150", "0" })
 	void validNegativeOrZero(BigInteger value) {
 		Predicate<BigInteger> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/BigIntegerConstraintTest.java
@@ -142,6 +142,22 @@ class BigIntegerConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "99", "100" })
+	void invalidNegaitveOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-150", "0" })
+	void validNegaitveOrZero(BigInteger value) {
+		Predicate<BigInteger> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(BigInteger value) {
 		Predicate<BigInteger> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
@@ -133,7 +133,7 @@ class ByteConstraintTest {
 	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(byte value) {
 		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -141,7 +141,7 @@ class ByteConstraintTest {
 	@ValueSource(strings = { "-101", "-120", "0" })
 	void validNegativeOrZero(byte value) {
 		Predicate<Byte> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ByteConstraintTest.java
@@ -131,6 +131,22 @@ class ByteConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "99", "100" })
+	void invalidNegaitveOrZero(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "-101", "-120", "0" })
+	void validNegaitveOrZero(byte value) {
+		Predicate<Byte> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "99", "100" })
 	void invalidNegativeOrZero(byte value) {
 		Predicate<Byte> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
@@ -128,6 +128,22 @@ class DoubleConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(doubles = { 99.0, 100 })
+	void invalidNegaitveOrZero(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { -101, -120, 0 })
+	void validNegaitveOrZero(double value) {
+		Predicate<Double> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = { 99.0, 100 })
 	void invalidNegativeOrZero(double value) {
 		Predicate<Double> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/DoubleConstraintTest.java
@@ -130,7 +130,7 @@ class DoubleConstraintTest {
 	@ValueSource(doubles = { 99.0, 100 })
 	void invalidNegativeOrZero(double value) {
 		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -138,7 +138,7 @@ class DoubleConstraintTest {
 	@ValueSource(doubles = { -101, -120, 0 })
 	void validNegativeOrZero(double value) {
 		Predicate<Double> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
@@ -130,7 +130,7 @@ class FloatConstraintTest {
 	@ValueSource(floats = { 99.0f, 100f })
 	void invalidNegativeOrZero(float value) {
 		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -138,7 +138,7 @@ class FloatConstraintTest {
 	@ValueSource(floats = { -101f, -120f, 0f })
 	void validNegativeOrZero(float value) {
 		Predicate<Float> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/FloatConstraintTest.java
@@ -128,6 +128,22 @@ class FloatConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(floats = { 99.0f, 100f })
+	void invalidNegaitveOrZero(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { -101f, -120f, 0f })
+	void validNegaitveOrZero(float value) {
+		Predicate<Float> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = { 99.0f, 100f })
 	void invalidNegativeOrZero(float value) {
 		Predicate<Float> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
@@ -128,6 +128,22 @@ class IntegerConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(ints = { 99, 100 })
+	void invalidNegaitveOrZero(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { -101, -120, 0 })
+	void validNegaitveOrZero(int value) {
+		Predicate<Integer> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 99, 100 })
 	void invalidNegativeOrZero(int value) {
 		Predicate<Integer> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/IntegerConstraintTest.java
@@ -130,7 +130,7 @@ class IntegerConstraintTest {
 	@ValueSource(ints = { 99, 100 })
 	void invalidNegativeOrZero(int value) {
 		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -138,7 +138,7 @@ class IntegerConstraintTest {
 	@ValueSource(ints = { -101, -120, 0 })
 	void validNegativeOrZero(int value) {
 		Predicate<Integer> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
@@ -130,7 +130,7 @@ class LongConstraintTest {
 	@ValueSource(longs = { 99, 100 })
 	void invalidNegativeOrZero(long value) {
 		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -138,7 +138,7 @@ class LongConstraintTest {
 	@ValueSource(longs = { -101, -120, 0 })
 	void validNegativeOrZero(long value) {
 		Predicate<Long> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/LongConstraintTest.java
@@ -128,6 +128,22 @@ class LongConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(longs = { 99, 100 })
+	void invalidNegaitveOrZero(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { -101, -120, 0 })
+	void validNegaitveOrZero(long value) {
+		Predicate<Long> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 99, 100 })
 	void invalidNegativeOrZero(long value) {
 		Predicate<Long> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
@@ -132,6 +132,22 @@ class ShortConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(shorts = { 99, 100 })
+	void invalidNegaitveOrZero(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { -101, -120, 0 })
+	void validNegaitveOrZero(short value) {
+		Predicate<Short> predicate = retrievePredicate(
+				NumericConstraintBase::negaitveOrZero);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(shorts = { 99, 100 })
 	void invalidNegativeOrZero(short value) {
 		Predicate<Short> predicate = retrievePredicate(
 				NumericConstraintBase::negativeOrZero);

--- a/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/ShortConstraintTest.java
@@ -134,7 +134,7 @@ class ShortConstraintTest {
 	@ValueSource(shorts = { 99, 100 })
 	void invalidNegativeOrZero(short value) {
 		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isFalse();
 	}
 
@@ -142,7 +142,7 @@ class ShortConstraintTest {
 	@ValueSource(shorts = { -101, -120, 0 })
 	void validNegativeOrZero(short value) {
 		Predicate<Short> predicate = retrievePredicate(
-				NumericConstraintBase::negaitveOrZero);
+				NumericConstraintBase::negativeOrZero);
 		assertThat(predicate.test(value)).isTrue();
 	}
 


### PR DESCRIPTION
This fixes a method name typo from negaitveOrZero to negativeOrZero in the constraint classes for numeric types.