### PR TITLE
Add isLocalDate to CharSequenceConstraint

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -22,6 +22,9 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -183,6 +186,22 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	}
 
 	/**
+	 * @since 0.11.3
+	 */
+	private CharSequenceConstraint<T, E> isValidLocalDate(String pattern) {
+		this.predicates().add(ConstraintPredicate.of(x -> {
+			try {
+				LocalDate.parse(x, DateTimeFormatter.ofPattern(pattern));
+				return true;
+			}
+			catch (DateTimeParseException ignored) {
+				return false;
+			}
+		}, CHAR_SEQUENCE_LOCAL_DATE, () -> new Object[] {pattern}, VALID));
+		return this;
+	}
+
+	/**
 	 * @since 0.6.0
 	 */
 	public CharSequenceConstraint<T, E> isByte() {
@@ -236,6 +255,20 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	 */
 	public CharSequenceConstraint<T, E> isBigDecimal() {
 		return this.isValidRepresentationOf(BigDecimal::new, CHAR_SEQUENCE_BIGDECIMAL);
+	}
+
+	/**
+	 * @since 0.11.3
+	 */
+	public CharSequenceConstraint<T, E> isLocalDate() {
+		return this.isValidLocalDate("yyyy-MM-dd");
+	}
+
+	/**
+	 * @since 0.11.3
+	 */
+	public CharSequenceConstraint<T, E> isLocalDate(String pattern) {
+		return this.isValidLocalDate(pattern);
 	}
 
 	public EmojiConstraint<T, E> emoji() {

--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -193,13 +193,14 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	private CharSequenceConstraint<T, E> isLocalDate(String pattern, Locale locale) {
 		this.predicates().add(ConstraintPredicate.of(x -> {
 			try {
-				DateTimeFormatter.ofPattern(pattern, locale).withResolverStyle(ResolverStyle.STRICT).parse(x);
+				DateTimeFormatter.ofPattern(pattern, locale)
+						.withResolverStyle(ResolverStyle.STRICT).parse(x);
 				return true;
 			}
 			catch (DateTimeParseException ignored) {
 				return false;
 			}
-		}, CHAR_SEQUENCE_LOCAL_DATE, () -> new Object[] {pattern}, VALID));
+		}, CHAR_SEQUENCE_LOCAL_DATE, () -> new Object[] { pattern }, VALID));
 		return this;
 	}
 

--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -25,9 +25,11 @@ import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -186,12 +188,12 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	}
 
 	/**
-	 * @since 0.11.3
+	 * @since 0.12.0
 	 */
-	private CharSequenceConstraint<T, E> isValidLocalDate(String pattern) {
+	private CharSequenceConstraint<T, E> isValidLocalDate(String pattern, Locale locale) {
 		this.predicates().add(ConstraintPredicate.of(x -> {
 			try {
-				LocalDate.parse(x, DateTimeFormatter.ofPattern(pattern));
+				DateTimeFormatter.ofPattern(pattern, locale).withResolverStyle(ResolverStyle.STRICT).parse(x);
 				return true;
 			}
 			catch (DateTimeParseException ignored) {
@@ -258,17 +260,17 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	}
 
 	/**
-	 * @since 0.11.3
+	 * @since 0.12.0
 	 */
-	public CharSequenceConstraint<T, E> isLocalDate() {
-		return this.isValidLocalDate("yyyy-MM-dd");
+	public CharSequenceConstraint<T, E> isIsoLocalDate() {
+		return this.isLocalDate("uuuu-MM-dd");
 	}
 
 	/**
-	 * @since 0.11.3
+	 * @since 0.12.0
 	 */
 	public CharSequenceConstraint<T, E> isLocalDate(String pattern) {
-		return this.isValidLocalDate(pattern);
+		return this.isValidLocalDate(pattern, Locale.getDefault());
 	}
 
 	public EmojiConstraint<T, E> emoji() {

--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -190,7 +190,7 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	/**
 	 * @since 0.12.0
 	 */
-	private CharSequenceConstraint<T, E> isValidLocalDate(String pattern, Locale locale) {
+	private CharSequenceConstraint<T, E> isLocalDate(String pattern, Locale locale) {
 		this.predicates().add(ConstraintPredicate.of(x -> {
 			try {
 				DateTimeFormatter.ofPattern(pattern, locale).withResolverStyle(ResolverStyle.STRICT).parse(x);
@@ -270,7 +270,7 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	 * @since 0.12.0
 	 */
 	public CharSequenceConstraint<T, E> isLocalDate(String pattern) {
-		return this.isValidLocalDate(pattern, Locale.getDefault());
+		return this.isLocalDate(pattern, Locale.getDefault());
 	}
 
 	public EmojiConstraint<T, E> emoji() {

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -97,9 +97,9 @@ public interface ViolationMessage {
 		CHAR_SEQUENCE_BIGDECIMAL("charSequence.bigdecimal",
 				"\"{0}\" must be a valid representation of a big decimal"), //
 		CHAR_SEQUENCE_LOCAL_DATE("charSequence.localdate",
-				"\"{0}\" must be a valid representation of a local date using the pattern: {1}. The give value is: {2}"),
-		BYTE_SIZE_LESS_THAN("byteSize.lessThan",
-				"The byte size of \"{0}\" must be less than {1}. The given size is {2}"), //
+				"\"{0}\" must be a valid representation of a local date using the pattern: {1}. The give value is: {2}"), BYTE_SIZE_LESS_THAN(
+						"byteSize.lessThan",
+						"The byte size of \"{0}\" must be less than {1}. The given size is {2}"), //
 		BYTE_SIZE_LESS_THAN_OR_EQUAL("byteSize.lessThanOrEqual",
 				"The byte size of \"{0}\" must be less than or equal to {1}. The given size is {2}"), //
 		BYTE_SIZE_GREATER_THAN("byteSize.greaterThan",

--- a/src/main/java/am/ik/yavi/core/ViolationMessage.java
+++ b/src/main/java/am/ik/yavi/core/ViolationMessage.java
@@ -96,6 +96,8 @@ public interface ViolationMessage {
 				"\"{0}\" must be a valid representation of a big integer"), //
 		CHAR_SEQUENCE_BIGDECIMAL("charSequence.bigdecimal",
 				"\"{0}\" must be a valid representation of a big decimal"), //
+		CHAR_SEQUENCE_LOCAL_DATE("charSequence.localdate",
+				"\"{0}\" must be a valid representation of a local date using the pattern: {1}. The give value is: {2}"),
 		BYTE_SIZE_LESS_THAN("byteSize.lessThan",
 				"The byte size of \"{0}\" must be less than {1}. The given size is {2}"), //
 		BYTE_SIZE_LESS_THAN_OR_EQUAL("byteSize.lessThanOrEqual",

--- a/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
@@ -534,7 +534,7 @@ class CharSequenceConstraintTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01"})
 	void validIsLocalDate(String value) {
-		Predicate<String> predicate = retrievePredicate(CharSequenceConstraint::isLocalDate);
+		Predicate<String> predicate = retrievePredicate(CharSequenceConstraint::isIsoLocalDate);
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
@@ -532,14 +532,15 @@ class CharSequenceConstraintTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01"})
+	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01" })
 	void validIsLocalDate(String value) {
-		Predicate<String> predicate = retrievePredicate(CharSequenceConstraint::isIsoLocalDate);
+		Predicate<String> predicate = retrievePredicate(
+				CharSequenceConstraint::isIsoLocalDate);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01"})
+	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01" })
 	void inValidIsLocalDateWithPattern(String value) {
 		String pattern = "dd/MM/yyyy";
 		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));
@@ -547,7 +548,7 @@ class CharSequenceConstraintTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "01/01/2022", "31/01/2022", "31/12/2022"})
+	@ValueSource(strings = { "01/01/2022", "31/01/2022", "31/12/2022" })
 	void validIsLocalDateWithPattern(String value) {
 		String pattern = "dd/MM/yyyy";
 		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));

--- a/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
@@ -531,6 +531,29 @@ class CharSequenceConstraintTest {
 		assertThat(predicate.test(value)).isFalse();
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01"})
+	void validIsLocalDate(String value) {
+		Predicate<String> predicate = retrievePredicate(CharSequenceConstraint::isLocalDate);
+		assertThat(predicate.test(value)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01"})
+	void inValidIsLocalDateWithPattern(String value) {
+		String pattern = "dd/MM/yyyy";
+		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));
+		assertThat(predicate.test(value)).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "01/01/2022", "31/01/2022", "31/12/2022"})
+	void validIsLocalDateWithPattern(String value) {
+		String pattern = "dd/MM/yyyy";
+		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));
+		assertThat(predicate.test(value)).isTrue();
+	}
+
 	private static Predicate<String> retrievePredicate(
 			Function<CharSequenceConstraint<String, String>, CharSequenceConstraint<String, String>> constraint) {
 		return constraint.apply(new CharSequenceConstraint<>()).predicates().peekFirst()

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -21,7 +21,12 @@ import am.ik.yavi.PhoneNumber;
 import am.ik.yavi.arguments.Arguments1Validator;
 import am.ik.yavi.arguments.Arguments3Validator;
 import am.ik.yavi.builder.ValidatorBuilder;
+import am.ik.yavi.constraint.CharSequenceConstraint;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,5 +76,27 @@ class ValueValidatorTest {
 				.isFalse();
 		assertThat(addressValidator.andThen(foreignAddressValidator)
 				.validate("J", "tokyo", "+0123456789").isValid()).isFalse();
+	}
+
+	@Test
+	void invalidPatternStringToLocalDateValidator() {
+		ValueValidator<String, LocalDate> localDateValidator
+				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", CharSequenceConstraint::isLocalDate)
+				.build().applicative().andThen(LocalDate::parse);
+		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
+		Assertions.assertThat(localDateValidated.isValid()).isFalse();
+		Assertions.assertThat(localDateValidated.errors()).hasSize(1);
+		Assertions.assertThat(localDateValidated.errors().get(0).messageKey()).isEqualTo("charSequence.localdate");
+		Assertions.assertThat(localDateValidated.errors().get(0).message()).isEqualTo("\"myLocalDate\" must be a valid representation of a local date using the pattern: yyyy-MM-dd. The give value is: 31/01/2022");
+	}
+
+	@Test
+	void validStringToLocalDateValidator() {
+		ValueValidator<String, LocalDate> localDateValidator
+				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", c -> c.isLocalDate("dd/MM/yyyy"))
+				.build().applicative().andThen(s -> LocalDate.parse(s, DateTimeFormatter.ofPattern("dd/MM/yyyy")));
+		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
+		Assertions.assertThat(localDateValidated.isValid()).isTrue();
+		Assertions.assertThat(localDateValidated.value()).isEqualTo(LocalDate.of(2022,1,31));
 	}
 }

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -80,23 +80,31 @@ class ValueValidatorTest {
 
 	@Test
 	void invalidPatternStringToLocalDateValidator() {
-		ValueValidator<String, LocalDate> localDateValidator
-				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", CharSequenceConstraint::isIsoLocalDate)
+		ValueValidator<String, LocalDate> localDateValidator = ValidatorBuilder
+				.<String> of()
+				._string(f -> f, "myLocalDate", CharSequenceConstraint::isIsoLocalDate)
 				.build().applicative().andThen(LocalDate::parse);
-		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
+		final Validated<LocalDate> localDateValidated = localDateValidator
+				.validate("31/01/2022");
 		Assertions.assertThat(localDateValidated.isValid()).isFalse();
 		Assertions.assertThat(localDateValidated.errors()).hasSize(1);
-		Assertions.assertThat(localDateValidated.errors().get(0).messageKey()).isEqualTo("charSequence.localdate");
-		Assertions.assertThat(localDateValidated.errors().get(0).message()).isEqualTo("\"myLocalDate\" must be a valid representation of a local date using the pattern: uuuu-MM-dd. The give value is: 31/01/2022");
+		Assertions.assertThat(localDateValidated.errors().get(0).messageKey())
+				.isEqualTo("charSequence.localdate");
+		Assertions.assertThat(localDateValidated.errors().get(0).message()).isEqualTo(
+				"\"myLocalDate\" must be a valid representation of a local date using the pattern: uuuu-MM-dd. The give value is: 31/01/2022");
 	}
 
 	@Test
 	void validStringToLocalDateValidator() {
-		ValueValidator<String, LocalDate> localDateValidator
-				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", c -> c.isLocalDate("dd/MM/yyyy"))
-				.build().applicative().andThen(s -> LocalDate.parse(s, DateTimeFormatter.ofPattern("dd/MM/yyyy")));
-		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
+		ValueValidator<String, LocalDate> localDateValidator = ValidatorBuilder
+				.<String> of()
+				._string(f -> f, "myLocalDate", c -> c.isLocalDate("dd/MM/yyyy")).build()
+				.applicative().andThen(s -> LocalDate.parse(s,
+						DateTimeFormatter.ofPattern("dd/MM/yyyy")));
+		final Validated<LocalDate> localDateValidated = localDateValidator
+				.validate("31/01/2022");
 		Assertions.assertThat(localDateValidated.isValid()).isTrue();
-		Assertions.assertThat(localDateValidated.value()).isEqualTo(LocalDate.of(2022,1,31));
+		Assertions.assertThat(localDateValidated.value())
+				.isEqualTo(LocalDate.of(2022, 1, 31));
 	}
 }

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -81,13 +81,13 @@ class ValueValidatorTest {
 	@Test
 	void invalidPatternStringToLocalDateValidator() {
 		ValueValidator<String, LocalDate> localDateValidator
-				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", CharSequenceConstraint::isLocalDate)
+				= ValidatorBuilder.<String>of()._string(f -> f, "myLocalDate", CharSequenceConstraint::isIsoLocalDate)
 				.build().applicative().andThen(LocalDate::parse);
 		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
 		Assertions.assertThat(localDateValidated.isValid()).isFalse();
 		Assertions.assertThat(localDateValidated.errors()).hasSize(1);
 		Assertions.assertThat(localDateValidated.errors().get(0).messageKey()).isEqualTo("charSequence.localdate");
-		Assertions.assertThat(localDateValidated.errors().get(0).message()).isEqualTo("\"myLocalDate\" must be a valid representation of a local date using the pattern: yyyy-MM-dd. The give value is: 31/01/2022");
+		Assertions.assertThat(localDateValidated.errors().get(0).message()).isEqualTo("\"myLocalDate\" must be a valid representation of a local date using the pattern: uuuu-MM-dd. The give value is: 31/01/2022");
 	}
 
 	@Test


### PR DESCRIPTION
Hi this pull request addes isLocalDate validation in CharSequenceConstraint. This validates if a given string is in ISO format or in a given pattern format.