### PR TITLE
Deprecate isLocalDate/isIsoLocalDate in favor of

### DIFF
--- a/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/CharSequenceConstraint.java
@@ -126,6 +126,7 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 
 	/**
 	 * Does the given value start with the {@code prefix}
+	 *
 	 * @param prefix the prefix the value has to start with
 	 * @since 0.10.0
 	 */
@@ -139,6 +140,7 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 
 	/**
 	 * Does the given value end with the {@code suffix}
+	 *
 	 * @param suffix the suffix the value has to end with
 	 * @since 0.10.0
 	 */
@@ -261,17 +263,37 @@ public class CharSequenceConstraint<T, E extends CharSequence>
 	}
 
 	/**
-	 * @since 0.12.0
+	 * @since 0.12.1
 	 */
-	public CharSequenceConstraint<T, E> isIsoLocalDate() {
-		return this.isLocalDate("uuuu-MM-dd");
+	public CharSequenceConstraint<T, E> isoLocalDate() {
+		return this.localDate("uuuu-MM-dd");
 	}
 
 	/**
+	 * Use {@link #isoLocalDate()} instead
+	 *
 	 * @since 0.12.0
 	 */
-	public CharSequenceConstraint<T, E> isLocalDate(String pattern) {
+	@Deprecated
+	public CharSequenceConstraint<T, E> isIsoLocalDate() {
+		return this.isoLocalDate();
+	}
+
+	/**
+	 * @since 0.12.1
+	 */
+	public CharSequenceConstraint<T, E> localDate(String pattern) {
 		return this.isLocalDate(pattern, Locale.getDefault());
+	}
+
+	/**
+	 * Use {@link #localDate(String)} instead
+	 *
+	 * @since 0.12.0
+	 */
+	@Deprecated
+	public CharSequenceConstraint<T, E> isLocalDate(String pattern) {
+		return this.localDate(pattern);
 	}
 
 	public EmojiConstraint<T, E> emoji() {

--- a/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/CharSequenceConstraintTest.java
@@ -533,25 +533,25 @@ class CharSequenceConstraintTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01" })
-	void validIsLocalDate(String value) {
+	void validLocalDate(String value) {
 		Predicate<String> predicate = retrievePredicate(
-				CharSequenceConstraint::isIsoLocalDate);
+				CharSequenceConstraint::isoLocalDate);
 		assertThat(predicate.test(value)).isTrue();
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "2022-02-02", "2022-12-31", "2022-01-01" })
-	void inValidIsLocalDateWithPattern(String value) {
+	void inValidLocalDateWithPattern(String value) {
 		String pattern = "dd/MM/yyyy";
-		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));
+		Predicate<String> predicate = retrievePredicate(c -> c.localDate(pattern));
 		assertThat(predicate.test(value)).isFalse();
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "01/01/2022", "31/01/2022", "31/12/2022" })
-	void validIsLocalDateWithPattern(String value) {
+	void validLocalDateWithPattern(String value) {
 		String pattern = "dd/MM/yyyy";
-		Predicate<String> predicate = retrievePredicate(c -> c.isLocalDate(pattern));
+		Predicate<String> predicate = retrievePredicate(c -> c.localDate(pattern));
 		assertThat(predicate.test(value)).isTrue();
 	}
 

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -82,7 +82,7 @@ class ValueValidatorTest {
 	void invalidPatternStringToLocalDateValidator() {
 		ValueValidator<String, LocalDate> localDateValidator = ValidatorBuilder
 				.<String> of()
-				._string(f -> f, "myLocalDate", CharSequenceConstraint::isIsoLocalDate)
+				._string(f -> f, "myLocalDate", CharSequenceConstraint::isoLocalDate)
 				.build().applicative().andThen(LocalDate::parse);
 		final Validated<LocalDate> localDateValidated = localDateValidator
 				.validate("31/01/2022");
@@ -98,7 +98,7 @@ class ValueValidatorTest {
 	void validStringToLocalDateValidator() {
 		ValueValidator<String, LocalDate> localDateValidator = ValidatorBuilder
 				.<String> of()
-				._string(f -> f, "myLocalDate", c -> c.isLocalDate("dd/MM/yyyy")).build()
+				._string(f -> f, "myLocalDate", c -> c.localDate("dd/MM/yyyy")).build()
 				.applicative().andThen(s -> LocalDate.parse(s,
 						DateTimeFormatter.ofPattern("dd/MM/yyyy")));
 		final Validated<LocalDate> localDateValidated = localDateValidator


### PR DESCRIPTION
 localDate/isoLocalDate for the naming consistency