### PR TITLE
Throw UnsupportedOperationException when default `lazy` method is called

### DIFF
--- a/scripts/generate-args.sh
+++ b/scripts/generate-args.sh
@@ -325,10 +325,7 @@ $(cat <<EOD
 	 * @since 0.10.0
 	 */
 	default ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), Supplier<X>> lazy() {
-	  // WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(${class}.class.getName())
-			.warning("the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(${args}) {

--- a/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
@@ -79,10 +79,7 @@ public interface Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X
 	 * @since 0.10.0
 	 */
 	default Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments10Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
@@ -81,10 +81,7 @@ public interface Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments11Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
@@ -81,10 +81,7 @@ public interface Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments12Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
@@ -82,10 +82,7 @@ public interface Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments13Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
@@ -83,10 +83,7 @@ public interface Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments14Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
@@ -83,10 +83,7 @@ public interface Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments15Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
@@ -84,10 +84,7 @@ public interface Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	 * @since 0.10.0
 	 */
 	default Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments16Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
@@ -103,10 +103,7 @@ public interface Arguments1Validator<A1, X> extends ValueValidator<A1, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments1Validator<A1, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments1Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1) {

--- a/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
@@ -72,10 +72,7 @@ public interface Arguments2Validator<A1, A2, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments2Validator<A1, A2, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments2Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2) {

--- a/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
@@ -73,10 +73,7 @@ public interface Arguments3Validator<A1, A2, A3, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments3Validator<A1, A2, A3, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments3Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3) {

--- a/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
@@ -73,10 +73,7 @@ public interface Arguments4Validator<A1, A2, A3, A4, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments4Validator<A1, A2, A3, A4, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments4Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
@@ -74,10 +74,7 @@ public interface Arguments5Validator<A1, A2, A3, A4, A5, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments5Validator<A1, A2, A3, A4, A5, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments5Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
@@ -78,10 +78,7 @@ public interface Arguments6Validator<A1, A2, A3, A4, A5, A6, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments6Validator<A1, A2, A3, A4, A5, A6, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments6Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
@@ -78,10 +78,7 @@ public interface Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments7Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
@@ -78,10 +78,7 @@ public interface Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments8Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,

--- a/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
@@ -79,10 +79,7 @@ public interface Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X> {
 	 * @since 0.10.0
 	 */
 	default Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, Supplier<X>> lazy() {
-		// WARNING:: The default implementation is not really lazy!
-		java.util.logging.Logger.getLogger(Arguments9Validator.class.getName()).warning(
-				"the default implementation of lazy() is called which is not really lazy!");
-		return this.andThen(x -> () -> x);
+		throw new UnsupportedOperationException("lazy is not implemented!");
 	}
 
 	default Validated<X> validate(@Nullable A1 a1, @Nullable A2 a2, @Nullable A3 a3,


### PR DESCRIPTION
instead of warning log