### PR TITLE
Added explicit enum constraint support

### DIFF
--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -46,6 +46,7 @@ import am.ik.yavi.constraint.CharSequenceConstraint;
 import am.ik.yavi.constraint.CharacterConstraint;
 import am.ik.yavi.constraint.CollectionConstraint;
 import am.ik.yavi.constraint.DoubleConstraint;
+import am.ik.yavi.constraint.EnumConstraint;
 import am.ik.yavi.constraint.FloatConstraint;
 import am.ik.yavi.constraint.InstantConstraint;
 import am.ik.yavi.constraint.IntegerConstraint;
@@ -222,6 +223,22 @@ public class ValidatorBuilder<T> implements Cloneable {
 	public ValidatorBuilder<T> constraint(ToCharSequence<T, String> f, String name,
 			Function<CharSequenceConstraint<T, String>, CharSequenceConstraint<T, String>> c) {
 		return this.constraint(f, name, c, CharSequenceConstraint::new);
+	}
+
+	/**
+	 * @since 0.14.0
+	 */
+	public <E extends Enum<E>> ValidatorBuilder<T> constraint(toEnum<T, E> f, String name,
+			Function<EnumConstraint<T, E>, EnumConstraint<T, E>> c) {
+		return this.constraint(f, name, c, EnumConstraint::new);
+	}
+
+	/**
+	 * @since 0.14.0
+	 */
+	public <E extends Enum<E>> ValidatorBuilder<T> _enum(toEnum<T, E> f, String name,
+			Function<EnumConstraint<T, E>, EnumConstraint<T, E>> c) {
+		return this.constraint(f, name, c);
 	}
 
 	/**
@@ -1144,6 +1161,9 @@ public class ValidatorBuilder<T> implements Cloneable {
 	}
 
 	public interface ToCharSequence<T, E extends CharSequence> extends Function<T, E> {
+	}
+
+	public interface toEnum<T, E extends Enum> extends Function<T, E> {
 	}
 
 	public interface ToCharacter<T> extends Function<T, Character> {

--- a/src/main/java/am/ik/yavi/constraint/EnumConstraint.java
+++ b/src/main/java/am/ik/yavi/constraint/EnumConstraint.java
@@ -1,0 +1,29 @@
+package am.ik.yavi.constraint;
+
+import am.ik.yavi.constraint.base.ConstraintBase;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+/**
+ * class for enum constraints
+ * @since 0.14.0
+ */
+public class EnumConstraint<T, E extends Enum<E>>
+		extends ConstraintBase<T, E, EnumConstraint<T, E>> {
+
+	@Override
+	public EnumConstraint<T, E> cast() {
+		return this;
+	}
+
+	public EnumConstraint<T, E> oneOf(E... values) throws IllegalArgumentException {
+		if (values.length == 0) {
+			throw new IllegalArgumentException("oneOf must accept at least one value");
+		}
+
+		EnumSet<E> enumSet = EnumSet.copyOf(Arrays.asList(values));
+
+		return super.oneOf(enumSet);
+	}
+}

--- a/src/main/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDsl.kt
+++ b/src/main/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDsl.kt
@@ -413,6 +413,10 @@ class ValidatorBuilderKt<T>(private val validatorBuilder: ValidatorBuilder<T>) {
 	) =
 		validatorBuilder.constraint(this, name) { it.apply(block) }
 
+	operator fun <E : Enum<E>?> KProperty1<T, E?>.invoke(block: EnumConstraint<T, E>.() -> Unit) =
+		validatorBuilder.constraint(this, this.name) { it.apply(block) }
+
+
 	infix fun <E> KProperty1<T, E?>.onObject(block: ObjectConstraint<T, E?>.() -> Unit) =
 		validatorBuilder.constraintOnObject(this, this.name) { it.apply(block) }
 

--- a/src/test/java/am/ik/yavi/constraint/EnumConstraintTest.java
+++ b/src/test/java/am/ik/yavi/constraint/EnumConstraintTest.java
@@ -1,0 +1,30 @@
+package am.ik.yavi.constraint;
+
+import am.ik.yavi.Color;
+import com.google.common.truth.Truth;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.function.Predicate;
+
+class EnumConstraintTest {
+	private final EnumConstraint<Color, Color> enumConstraint = new EnumConstraint<>();
+
+	@Test
+	public void testIllegalOneOfArgument(){
+		assertThrows(IllegalArgumentException.class, enumConstraint::oneOf);
+	}
+
+	@ParameterizedTest(name = "test oneOf(BLUE,RED) for {0} should return {1}")
+	@CsvSource({ "BLUE,true", "GREEN,false" })
+	void testIsOneOf(Color color, boolean expectedResult) {
+		Predicate<Color> predicate = enumConstraint.oneOf(Color.BLUE, Color.RED)
+				.predicates().peekFirst().predicate();
+
+		boolean actualResult = predicate.test(color);
+
+		Truth.assertThat(actualResult).isEqualTo(expectedResult);
+	}
+}

--- a/src/test/java/am/ik/yavi/core/EnumValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/EnumValidatorTest.java
@@ -1,0 +1,73 @@
+package am.ik.yavi.core;
+
+import am.ik.yavi.Color;
+import am.ik.yavi.Message;
+import am.ik.yavi.builder.ValidatorBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EnumValidatorTest {
+	Validator<Message> validator;
+
+	@Nested
+	class TestConstraintEnumValidator {
+		@BeforeEach
+		void beforeEach() {
+			validator = ValidatorBuilder.of(Message.class)
+					.constraint(Message::getColor, "color", c -> c.equalTo(Color.RED))
+					.build();
+		}
+
+		@Test
+		void testValidEnumValidation() {
+			Message message = new Message("text", Color.RED);
+
+			boolean isValid = validator.validate(message).isValid();
+
+			assertThat(isValid).isTrue();
+		}
+
+		@Test
+		void testInvalidValidEnum() {
+			Message message = new Message("text", Color.BLUE);
+
+			boolean isValid = validator.validate(message).isValid();
+
+			assertThat(isValid).isFalse();
+		}
+	}
+
+	@Nested
+	class TestExplicitEnumValidator {
+		@BeforeEach
+		void beforeEach() {
+			validator = ValidatorBuilder.of(Message.class)._enum(Message::getColor,
+					"color", c -> c.oneOf(EnumSet.of(Color.RED, Color.BLUE))).build();
+		}
+
+		@Test
+		void testValidEnumValidation() {
+			Message message = new Message("text", Color.RED);
+
+			boolean isValid = validator.validate(message).isValid();
+
+			assertThat(isValid).isTrue();
+		}
+
+		@Test
+		void testInvalidValidEnum() {
+			Message message = new Message("text", Color.GREEN);
+
+			boolean isValid = validator.validate(message).isValid();
+
+			assertThat(isValid).isFalse();
+		}
+	}
+}

--- a/src/test/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDslTest.kt
+++ b/src/test/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDslTest.kt
@@ -67,6 +67,13 @@ data class DemoForEachIfPresentMap(val x: Map<String, DemoString>?)
 data class DemoForEachArray(val x: Array<DemoString>)
 data class DemoForEachIfPresentArray(val x: Array<DemoString>?)
 data class DemoUnwrap(val x: Int, val y: Int)
+data class DemoEnum(val color: Color) {
+	enum class Color {
+		RED,
+		GREEN,
+		BLUE
+	}
+}
 
 class ValidatorBuilderKtDslTest {
 	private val demoStringValidator = validator<DemoString> {
@@ -215,6 +222,26 @@ class ValidatorBuilderKtDslTest {
 		Assertions.assertThat(violation.message())
 			.isEqualTo("""The size of "x" must be less than 5. The given size is 6""")
 		Assertions.assertThat(violation.messageKey()).isEqualTo("container.lessThan")
+	}
+
+	@Test
+	fun constraintOnENUM() {
+		val validator = validator<DemoEnum> {
+			DemoEnum::color {
+			equalTo(DemoEnum.Color.BLUE)
+			}
+		}
+
+		var demo = DemoEnum(DemoEnum.Color.BLUE)
+		var violations = validator.validate(demo)
+		Assertions.assertThat(violations.isValid).isTrue()
+
+		demo = DemoEnum(DemoEnum.Color.RED)
+		violations = validator.validate(demo)
+		Assertions.assertThat(violations.isValid).isFalse()
+		Assertions.assertThat(violations.size).isEqualTo(1)
+		val violation = violations[0]
+		Assertions.assertThat(violation.message()).isEqualTo("\"color\" must be equal to BLUE")
 	}
 
 	@Test


### PR DESCRIPTION
This pull request implements a new type of constraint for enums, enabling direct validation of enum values using both the constraint() and _enum() APIs in the ValidationBuilder

**Motivation:**
Previously, users had to rely on the more generic _object method for enums validation, which could be confusing as its usage appeared more suitable for custom unaccounted for classes