### PR TITLE
Fix type parameter order in ArgumentsValidatorBuilder delegation

### DIFF
--- a/scripts/generate-args.sh
+++ b/scripts/generate-args.sh
@@ -805,7 +805,7 @@ fi)
 
 $(if [ "${i}" != "${n}" ];then
 cat <<EOD
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) BigDecimal, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _bigDecimal(ValueValidator<BigDecimal, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) BigDecimal> _bigDecimal(ValueValidator<T, BigDecimal> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -818,7 +818,7 @@ cat <<EOD
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) BigInteger, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _bigInteger(ValueValidator<BigInteger, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) BigInteger> _bigInteger(ValueValidator<T, BigInteger> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -831,7 +831,7 @@ cat <<EOD
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Boolean, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _boolean(ValueValidator<Boolean, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Boolean> _boolean(ValueValidator<T, Boolean> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -844,7 +844,7 @@ cat <<EOD
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Double, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _double(ValueValidator<Double, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Double> _double(ValueValidator<T, Double> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -857,7 +857,7 @@ cat <<EOD
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) E, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _enum(ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) E> _enum(ValueValidator<T, E> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -870,7 +870,7 @@ cat <<EOD
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Float, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _float(ValueValidator<Float, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Float> _float(ValueValidator<T, Float> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -883,7 +883,7 @@ cat <<EOD
 		return this._float(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Instant, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _instant(ValueValidator<Instant, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Instant> _instant(ValueValidator<T, Instant> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -896,7 +896,7 @@ cat <<EOD
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Integer, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _integer(ValueValidator<Integer, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Integer> _integer(ValueValidator<T, Integer> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -909,7 +909,7 @@ cat <<EOD
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) LocalDateTime, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _localDateTime(ValueValidator<LocalDateTime, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) LocalDateTime> _localDateTime(ValueValidator<T, LocalDateTime> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -922,7 +922,7 @@ cat <<EOD
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) LocalTime, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _localTime(ValueValidator<LocalTime, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) LocalTime> _localTime(ValueValidator<T, LocalTime> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -935,7 +935,7 @@ cat <<EOD
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Long, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _long(ValueValidator<Long, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Long> _long(ValueValidator<T, Long> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -961,7 +961,7 @@ cat <<EOD
 		return this._object(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) OffsetDateTime, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _offsetDateTime(ValueValidator<OffsetDateTime, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) OffsetDateTime> _offsetDateTime(ValueValidator<T, OffsetDateTime> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -974,7 +974,7 @@ cat <<EOD
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Short, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _short(ValueValidator<Short, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Short> _short(ValueValidator<T, Short> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -987,7 +987,7 @@ cat <<EOD
 		return this._short(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) String, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _string(ValueValidator<String, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) String> _string(ValueValidator<T, String> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -1000,7 +1000,7 @@ cat <<EOD
 		return this._string(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) YearMonth, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _yearMonth(ValueValidator<YearMonth, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) YearMonth> _yearMonth(ValueValidator<T, YearMonth> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -1013,7 +1013,7 @@ cat <<EOD
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) Year, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _year(ValueValidator<Year, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) Year> _year(ValueValidator<T, Year> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 
@@ -1026,7 +1026,7 @@ cat <<EOD
 		return this._year(name, Function.identity());
 	}
 
-	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) ZonedDateTime, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) T> _zonedDateTime(ValueValidator<ZonedDateTime, T> validator) {
+	public <T> ${next_class}<$(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done);fi) T, $(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "R${j}, ";done);fi) ZonedDateTime> _zonedDateTime(ValueValidator<T, ZonedDateTime> validator) {
 		return new ${next_class}<>($(if [ "${i}" -gt 0 ];then echo $(for j in `seq 1 ${i}`;do echo -n "this.v${j}, ";done); fi) validator);
 	}
 

--- a/src/main/java/am/ik/yavi/builder/Arguments10ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments10ValidatorBuilder.java
@@ -95,8 +95,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v10 = v10;
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -112,8 +112,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -129,8 +129,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -146,8 +146,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -163,8 +163,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -180,8 +180,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -197,8 +197,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -214,8 +214,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -231,8 +231,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -249,8 +249,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -266,8 +266,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -300,8 +300,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -318,8 +318,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -335,8 +335,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -352,8 +352,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -369,8 +369,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}
@@ -386,8 +386,8 @@ public final class Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments11ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments11ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments11ValidatorBuilder.java
@@ -98,8 +98,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v11 = v11;
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -116,8 +116,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -134,8 +134,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -152,8 +152,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -170,8 +170,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -188,8 +188,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -206,8 +206,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -224,8 +224,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -242,8 +242,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -261,8 +261,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -279,8 +279,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -315,8 +315,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -334,8 +334,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -352,8 +352,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -370,8 +370,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -388,8 +388,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);
@@ -406,8 +406,8 @@ public final class Arguments11ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments12ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11,
 				validator);

--- a/src/main/java/am/ik/yavi/builder/Arguments12ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments12ValidatorBuilder.java
@@ -102,8 +102,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v12 = v12;
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -120,8 +120,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -138,8 +138,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -156,8 +156,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -174,8 +174,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -192,8 +192,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -210,8 +210,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -228,8 +228,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -246,8 +246,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -265,8 +265,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -283,8 +283,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -319,8 +319,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -338,8 +338,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -356,8 +356,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -374,8 +374,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -392,8 +392,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);
@@ -410,8 +410,8 @@ public final class Arguments12ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments13ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				validator);

--- a/src/main/java/am/ik/yavi/builder/Arguments13ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments13ValidatorBuilder.java
@@ -105,8 +105,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v13 = v13;
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -123,8 +123,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -141,8 +141,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -159,8 +159,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -177,8 +177,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -195,8 +195,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -213,8 +213,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -231,8 +231,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -249,8 +249,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -268,8 +268,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -286,8 +286,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -322,8 +322,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -341,8 +341,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -359,8 +359,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -377,8 +377,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -395,8 +395,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);
@@ -413,8 +413,8 @@ public final class Arguments13ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments14ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, validator);

--- a/src/main/java/am/ik/yavi/builder/Arguments14ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments14ValidatorBuilder.java
@@ -109,8 +109,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v14 = v14;
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -127,8 +127,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -145,8 +145,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -163,8 +163,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -181,8 +181,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -199,8 +199,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -217,8 +217,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -235,8 +235,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -253,8 +253,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -272,8 +272,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -290,8 +290,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -326,8 +326,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -345,8 +345,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -363,8 +363,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -381,8 +381,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -399,8 +399,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);
@@ -417,8 +417,8 @@ public final class Arguments14ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments15ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, validator);

--- a/src/main/java/am/ik/yavi/builder/Arguments15ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments15ValidatorBuilder.java
@@ -112,8 +112,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		this.v15 = v15;
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -130,8 +130,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -148,8 +148,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -166,8 +166,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -184,8 +184,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -202,8 +202,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -220,8 +220,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -238,8 +238,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -256,8 +256,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -275,8 +275,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -293,8 +293,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -329,8 +329,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -348,8 +348,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -366,8 +366,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -384,8 +384,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -402,8 +402,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);
@@ -420,8 +420,8 @@ public final class Arguments15ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments16ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments16ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, this.v10, this.v11, this.v12,
 				this.v13, this.v14, this.v15, validator);

--- a/src/main/java/am/ik/yavi/builder/Arguments1ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments1ValidatorBuilder.java
@@ -62,8 +62,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		this.v1 = v1;
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, BigDecimal, R1, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -78,8 +78,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, BigInteger, R1, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -94,8 +94,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Boolean, R1, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -108,8 +108,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Double, R1, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -122,8 +122,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments2ValidatorBuilder<A1, E, R1, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments2ValidatorBuilder<A1, T, R1, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -137,8 +137,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Float, R1, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -151,8 +151,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Instant, R1, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -165,8 +165,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Integer, R1, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -179,8 +179,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, LocalDateTime, R1, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -196,8 +196,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, LocalTime, R1, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -212,8 +212,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Long, R1, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -240,8 +240,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, OffsetDateTime, R1, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -257,8 +257,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Short, R1, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -271,8 +271,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, String, R1, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -285,8 +285,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, YearMonth, R1, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -301,8 +301,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, Year, R1, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 
@@ -315,8 +315,8 @@ public final class Arguments1ValidatorBuilder<A1, R1> {
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments2ValidatorBuilder<A1, ZonedDateTime, R1, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments2ValidatorBuilder<A1, T, R1, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments2ValidatorBuilder<>(this.v1, validator);
 	}
 

--- a/src/main/java/am/ik/yavi/builder/Arguments2ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments2ValidatorBuilder.java
@@ -67,8 +67,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		this.v2 = v2;
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, BigDecimal, R1, R2, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -83,8 +83,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, BigInteger, R1, R2, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -99,8 +99,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Boolean, R1, R2, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -115,8 +115,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Double, R1, R2, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -130,8 +130,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments3ValidatorBuilder<A1, A2, E, R1, R2, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -146,8 +146,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Float, R1, R2, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -160,8 +160,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Instant, R1, R2, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -176,8 +176,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Integer, R1, R2, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -192,8 +192,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, LocalDateTime, R1, R2, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -209,8 +209,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, LocalTime, R1, R2, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -225,8 +225,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Long, R1, R2, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -253,8 +253,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, OffsetDateTime, R1, R2, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -270,8 +270,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Short, R1, R2, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -284,8 +284,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, String, R1, R2, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -299,8 +299,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, YearMonth, R1, R2, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -315,8 +315,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, Year, R1, R2, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 
@@ -329,8 +329,8 @@ public final class Arguments2ValidatorBuilder<A1, A2, R1, R2> {
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments3ValidatorBuilder<A1, A2, ZonedDateTime, R1, R2, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments3ValidatorBuilder<A1, A2, T, R1, R2, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments3ValidatorBuilder<>(this.v1, this.v2, validator);
 	}
 

--- a/src/main/java/am/ik/yavi/builder/Arguments3ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments3ValidatorBuilder.java
@@ -70,8 +70,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		this.v3 = v3;
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, BigDecimal, R1, R2, R3, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -86,8 +86,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, BigInteger, R1, R2, R3, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -102,8 +102,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Boolean, R1, R2, R3, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -118,8 +118,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Double, R1, R2, R3, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -134,8 +134,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments4ValidatorBuilder<A1, A2, A3, E, R1, R2, R3, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -150,8 +150,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Float, R1, R2, R3, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -166,8 +166,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Instant, R1, R2, R3, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -182,8 +182,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Integer, R1, R2, R3, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -198,8 +198,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, LocalDateTime, R1, R2, R3, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -215,8 +215,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, LocalTime, R1, R2, R3, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -231,8 +231,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Long, R1, R2, R3, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -263,8 +263,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, OffsetDateTime, R1, R2, R3, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -280,8 +280,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Short, R1, R2, R3, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -296,8 +296,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, String, R1, R2, R3, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -312,8 +312,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, YearMonth, R1, R2, R3, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -328,8 +328,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, Year, R1, R2, R3, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 
@@ -344,8 +344,8 @@ public final class Arguments3ValidatorBuilder<A1, A2, A3, R1, R2, R3> {
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments4ValidatorBuilder<A1, A2, A3, ZonedDateTime, R1, R2, R3, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments4ValidatorBuilder<A1, A2, A3, T, R1, R2, R3, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments4ValidatorBuilder<>(this.v1, this.v2, this.v3, validator);
 	}
 

--- a/src/main/java/am/ik/yavi/builder/Arguments4ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments4ValidatorBuilder.java
@@ -74,8 +74,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		this.v4 = v4;
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, BigDecimal, R1, R2, R3, R4, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -91,8 +91,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, BigInteger, R1, R2, R3, R4, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -108,8 +108,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Boolean, R1, R2, R3, R4, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -125,8 +125,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Double, R1, R2, R3, R4, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -142,8 +142,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments5ValidatorBuilder<A1, A2, A3, A4, E, R1, R2, R3, R4, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -159,8 +159,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Float, R1, R2, R3, R4, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -176,8 +176,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Instant, R1, R2, R3, R4, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -193,8 +193,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Integer, R1, R2, R3, R4, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -210,8 +210,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, LocalDateTime, R1, R2, R3, R4, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -228,8 +228,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, LocalTime, R1, R2, R3, R4, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -245,8 +245,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Long, R1, R2, R3, R4, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -279,8 +279,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, OffsetDateTime, R1, R2, R3, R4, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -297,8 +297,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Short, R1, R2, R3, R4, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -314,8 +314,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, String, R1, R2, R3, R4, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -331,8 +331,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, YearMonth, R1, R2, R3, R4, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -348,8 +348,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, Year, R1, R2, R3, R4, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}
@@ -365,8 +365,8 @@ public final class Arguments4ValidatorBuilder<A1, A2, A3, A4, R1, R2, R3, R4> {
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, ZonedDateTime, R1, R2, R3, R4, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments5ValidatorBuilder<A1, A2, A3, A4, T, R1, R2, R3, R4, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments5ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments5ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments5ValidatorBuilder.java
@@ -77,8 +77,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		this.v5 = v5;
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, BigDecimal, R1, R2, R3, R4, R5, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -94,8 +94,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, BigInteger, R1, R2, R3, R4, R5, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -111,8 +111,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Boolean, R1, R2, R3, R4, R5, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -128,8 +128,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Double, R1, R2, R3, R4, R5, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -145,8 +145,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, E, R1, R2, R3, R4, R5, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -162,8 +162,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Float, R1, R2, R3, R4, R5, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -179,8 +179,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Instant, R1, R2, R3, R4, R5, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -196,8 +196,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Integer, R1, R2, R3, R4, R5, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -213,8 +213,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, LocalDateTime, R1, R2, R3, R4, R5, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -231,8 +231,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, LocalTime, R1, R2, R3, R4, R5, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -248,8 +248,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Long, R1, R2, R3, R4, R5, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -282,8 +282,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, OffsetDateTime, R1, R2, R3, R4, R5, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -300,8 +300,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Short, R1, R2, R3, R4, R5, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -317,8 +317,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, String, R1, R2, R3, R4, R5, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -334,8 +334,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, YearMonth, R1, R2, R3, R4, R5, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -351,8 +351,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, Year, R1, R2, R3, R4, R5, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}
@@ -368,8 +368,8 @@ public final class Arguments5ValidatorBuilder<A1, A2, A3, A4, A5, R1, R2, R3, R4
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, ZonedDateTime, R1, R2, R3, R4, R5, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, T, R1, R2, R3, R4, R5, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments6ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments6ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments6ValidatorBuilder.java
@@ -81,8 +81,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		this.v6 = v6;
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, BigDecimal, R1, R2, R3, R4, R5, R6, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -98,8 +98,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, BigInteger, R1, R2, R3, R4, R5, R6, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -115,8 +115,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Boolean, R1, R2, R3, R4, R5, R6, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -132,8 +132,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Double, R1, R2, R3, R4, R5, R6, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -149,8 +149,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, E, R1, R2, R3, R4, R5, R6, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -166,8 +166,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Float, R1, R2, R3, R4, R5, R6, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -183,8 +183,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Instant, R1, R2, R3, R4, R5, R6, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -200,8 +200,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Integer, R1, R2, R3, R4, R5, R6, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -217,8 +217,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, LocalDateTime, R1, R2, R3, R4, R5, R6, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -235,8 +235,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, LocalTime, R1, R2, R3, R4, R5, R6, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -252,8 +252,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Long, R1, R2, R3, R4, R5, R6, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -286,8 +286,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, OffsetDateTime, R1, R2, R3, R4, R5, R6, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -304,8 +304,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Short, R1, R2, R3, R4, R5, R6, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -321,8 +321,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, String, R1, R2, R3, R4, R5, R6, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -338,8 +338,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, YearMonth, R1, R2, R3, R4, R5, R6, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -355,8 +355,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, Year, R1, R2, R3, R4, R5, R6, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}
@@ -372,8 +372,8 @@ public final class Arguments6ValidatorBuilder<A1, A2, A3, A4, A5, A6, R1, R2, R3
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, ZonedDateTime, R1, R2, R3, R4, R5, R6, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, T, R1, R2, R3, R4, R5, R6, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments7ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments7ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments7ValidatorBuilder.java
@@ -84,8 +84,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		this.v7 = v7;
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, BigDecimal, R1, R2, R3, R4, R5, R6, R7, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -101,8 +101,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, BigInteger, R1, R2, R3, R4, R5, R6, R7, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -118,8 +118,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Boolean, R1, R2, R3, R4, R5, R6, R7, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -135,8 +135,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Double, R1, R2, R3, R4, R5, R6, R7, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -152,8 +152,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, E, R1, R2, R3, R4, R5, R6, R7, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -169,8 +169,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Float, R1, R2, R3, R4, R5, R6, R7, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -186,8 +186,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Instant, R1, R2, R3, R4, R5, R6, R7, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -203,8 +203,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Integer, R1, R2, R3, R4, R5, R6, R7, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -220,8 +220,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -238,8 +238,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, LocalTime, R1, R2, R3, R4, R5, R6, R7, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -255,8 +255,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Long, R1, R2, R3, R4, R5, R6, R7, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -289,8 +289,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -307,8 +307,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Short, R1, R2, R3, R4, R5, R6, R7, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -324,8 +324,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, String, R1, R2, R3, R4, R5, R6, R7, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -341,8 +341,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, YearMonth, R1, R2, R3, R4, R5, R6, R7, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -358,8 +358,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, Year, R1, R2, R3, R4, R5, R6, R7, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}
@@ -375,8 +375,8 @@ public final class Arguments7ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, R1, R2
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, T, R1, R2, R3, R4, R5, R6, R7, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments8ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments8ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments8ValidatorBuilder.java
@@ -88,8 +88,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		this.v8 = v8;
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -105,8 +105,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -122,8 +122,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -139,8 +139,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Double, R1, R2, R3, R4, R5, R6, R7, R8, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -156,8 +156,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, E, R1, R2, R3, R4, R5, R6, R7, R8, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -173,8 +173,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Float, R1, R2, R3, R4, R5, R6, R7, R8, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -190,8 +190,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Instant, R1, R2, R3, R4, R5, R6, R7, R8, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -207,8 +207,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Integer, R1, R2, R3, R4, R5, R6, R7, R8, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -224,8 +224,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -242,8 +242,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -259,8 +259,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Long, R1, R2, R3, R4, R5, R6, R7, R8, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -293,8 +293,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -311,8 +311,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Short, R1, R2, R3, R4, R5, R6, R7, R8, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -328,8 +328,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, String, R1, R2, R3, R4, R5, R6, R7, R8, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -345,8 +345,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -362,8 +362,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, Year, R1, R2, R3, R4, R5, R6, R7, R8, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}
@@ -379,8 +379,8 @@ public final class Arguments8ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, R1
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, T, R1, R2, R3, R4, R5, R6, R7, R8, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments9ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/Arguments9ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/Arguments9ValidatorBuilder.java
@@ -91,8 +91,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		this.v9 = v9;
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, BigDecimal, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -108,8 +108,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, BigInteger, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -125,8 +125,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Boolean, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -142,8 +142,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Double, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -159,8 +159,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, E, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -176,8 +176,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Float, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -193,8 +193,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Instant, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -210,8 +210,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Integer, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -227,8 +227,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, LocalDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -245,8 +245,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, LocalTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -262,8 +262,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Long, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -296,8 +296,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, OffsetDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -314,8 +314,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Short, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -331,8 +331,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, String, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -348,8 +348,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, YearMonth, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -365,8 +365,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, Year, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}
@@ -382,8 +382,8 @@ public final class Arguments9ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, ZonedDateTime, R1, R2, R3, R4, R5, R6, R7, R8, R9, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments10ValidatorBuilder<A1, A2, A3, A4, A5, A6, A7, A8, A9, T, R1, R2, R3, R4, R5, R6, R7, R8, R9, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments10ValidatorBuilder<>(this.v1, this.v2, this.v3, this.v4,
 				this.v5, this.v6, this.v7, this.v8, this.v9, validator);
 	}

--- a/src/main/java/am/ik/yavi/builder/YaviArguments.java
+++ b/src/main/java/am/ik/yavi/builder/YaviArguments.java
@@ -55,8 +55,8 @@ import am.ik.yavi.core.ValueValidator;
  */
 public final class YaviArguments {
 
-	public <T> Arguments1ValidatorBuilder<BigDecimal, T> _bigDecimal(
-			ValueValidator<BigDecimal, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, BigDecimal> _bigDecimal(
+			ValueValidator<T, BigDecimal> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -69,8 +69,8 @@ public final class YaviArguments {
 		return this._bigDecimal(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<BigInteger, T> _bigInteger(
-			ValueValidator<BigInteger, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, BigInteger> _bigInteger(
+			ValueValidator<T, BigInteger> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -83,8 +83,8 @@ public final class YaviArguments {
 		return this._bigInteger(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Boolean, T> _boolean(
-			ValueValidator<Boolean, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Boolean> _boolean(
+			ValueValidator<T, Boolean> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -97,8 +97,8 @@ public final class YaviArguments {
 		return this._boolean(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Double, T> _double(
-			ValueValidator<Double, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Double> _double(
+			ValueValidator<T, Double> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -111,8 +111,8 @@ public final class YaviArguments {
 		return this._double(name, Function.identity());
 	}
 
-	public <E extends Enum<E>, T> Arguments1ValidatorBuilder<E, T> _enum(
-			ValueValidator<E, T> validator) {
+	public <E extends Enum<E>, T> Arguments1ValidatorBuilder<T, E> _enum(
+			ValueValidator<T, E> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -125,8 +125,8 @@ public final class YaviArguments {
 		return this._enum(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Float, T> _float(
-			ValueValidator<Float, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Float> _float(
+			ValueValidator<T, Float> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -139,8 +139,8 @@ public final class YaviArguments {
 		return this._float(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Instant, T> _instant(
-			ValueValidator<Instant, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Instant> _instant(
+			ValueValidator<T, Instant> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -153,8 +153,8 @@ public final class YaviArguments {
 		return this._instant(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Integer, T> _integer(
-			ValueValidator<Integer, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Integer> _integer(
+			ValueValidator<T, Integer> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -167,8 +167,8 @@ public final class YaviArguments {
 		return this._integer(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<LocalDateTime, T> _localDateTime(
-			ValueValidator<LocalDateTime, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, LocalDateTime> _localDateTime(
+			ValueValidator<T, LocalDateTime> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -184,8 +184,8 @@ public final class YaviArguments {
 		return this._localDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<LocalTime, T> _localTime(
-			ValueValidator<LocalTime, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, LocalTime> _localTime(
+			ValueValidator<T, LocalTime> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -198,8 +198,8 @@ public final class YaviArguments {
 		return this._localTime(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Long, T> _long(
-			ValueValidator<Long, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Long> _long(
+			ValueValidator<T, Long> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -226,8 +226,8 @@ public final class YaviArguments {
 		return this._object(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<OffsetDateTime, T> _offsetDateTime(
-			ValueValidator<OffsetDateTime, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, OffsetDateTime> _offsetDateTime(
+			ValueValidator<T, OffsetDateTime> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -243,8 +243,8 @@ public final class YaviArguments {
 		return this._offsetDateTime(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Short, T> _short(
-			ValueValidator<Short, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Short> _short(
+			ValueValidator<T, Short> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -257,8 +257,8 @@ public final class YaviArguments {
 		return this._short(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<String, T> _string(
-			ValueValidator<String, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, String> _string(
+			ValueValidator<T, String> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -271,8 +271,8 @@ public final class YaviArguments {
 		return this._string(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<YearMonth, T> _yearMonth(
-			ValueValidator<YearMonth, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, YearMonth> _yearMonth(
+			ValueValidator<T, YearMonth> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -285,8 +285,8 @@ public final class YaviArguments {
 		return this._yearMonth(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<Year, T> _year(
-			ValueValidator<Year, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, Year> _year(
+			ValueValidator<T, Year> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 
@@ -299,8 +299,8 @@ public final class YaviArguments {
 		return this._year(name, Function.identity());
 	}
 
-	public <T> Arguments1ValidatorBuilder<ZonedDateTime, T> _zonedDateTime(
-			ValueValidator<ZonedDateTime, T> validator) {
+	public <T> Arguments1ValidatorBuilder<T, ZonedDateTime> _zonedDateTime(
+			ValueValidator<T, ZonedDateTime> validator) {
 		return new Arguments1ValidatorBuilder<>(validator);
 	}
 

--- a/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorsTest.java
+++ b/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorsTest.java
@@ -264,8 +264,8 @@ class ArgumentsValidatorsTest {
 						.apply(Address::new),
 				countryValidator.split(streetValidator).split(phoneNumberValidator)
 						.apply(Address::new),
-				Yavi.arguments()._string(countryValidator)._string(streetValidator)
-						._string(phoneNumberValidator).apply(Address::new));
+				Yavi.arguments()._object(countryValidator)._string(streetValidator)
+						._object(phoneNumberValidator).apply(Address::new));
 	}
 
 	static Stream<Arguments1Validator<Map<String, String>, Address>> combineValidators() {

--- a/src/test/java/am/ik/yavi/arguments/Gh286Test.java
+++ b/src/test/java/am/ik/yavi/arguments/Gh286Test.java
@@ -1,0 +1,154 @@
+package am.ik.yavi.arguments;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import am.ik.yavi.builder.IntegerValidatorBuilder;
+import am.ik.yavi.builder.StringValidatorBuilder;
+import am.ik.yavi.core.ConstraintViolations;
+import am.ik.yavi.core.Validated;
+import am.ik.yavi.jsr305.Nullable;
+import am.ik.yavi.validator.Yavi;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Gh286Test {
+	final Arguments1Validator<String, Integer> limitValidatgor = StringValidatorBuilder
+			.of("limit", c -> c.isInteger())
+			.build(s -> s != null && !s.isEmpty() ? Integer.parseInt(s) : 1_000)
+			.andThen(IntegerValidatorBuilder
+					.of("limit", c -> c.notNull().positive().lessThanOrEqual(1_000))
+					.build());
+
+	final Arguments1Validator<Map<String, String>, PaginationParam> validator = Yavi
+			.arguments() //
+			._string("cursor", c -> c.notBlank()) //
+			._integer(limitValidatgor) //
+			.apply(PaginationParam::new) //
+			.compose(queryParams -> Arguments.of(queryParams.get("cursor"),
+					queryParams.get("limit")));
+
+	@Test
+	void valid() {
+		PaginationParam param = validator.validated(new HashMap<String, String>() {
+			{
+				put("limit", "200");
+				put("cursor", "test");
+			}
+		});
+		assertThat(param).isEqualTo(new PaginationParam("test", 200));
+	}
+
+	@Test
+	void valid_default_limit() {
+		PaginationParam param = validator.validated(new HashMap<String, String>() {
+			{
+				put("cursor", "test");
+			}
+		});
+		assertThat(param).isEqualTo(new PaginationParam("test", 1_000));
+	}
+
+	@Test
+	void invalid_empty_map() {
+		Validated<PaginationParam> validated = validator.validate(Collections.emptyMap());
+		assertThat(validated.isValid()).isFalse();
+		ConstraintViolations violations = validated.errors();
+		assertThat(violations).hasSize(1);
+		assertThat(violations.get(0).name()).isEqualTo("cursor");
+		assertThat(violations.get(0).messageKey()).isEqualTo("charSequence.notBlank");
+	}
+
+	@Test
+	void invalid_limit_negative() {
+		Validated<PaginationParam> validated = validator
+				.validate(new HashMap<String, String>() {
+					{
+						put("cursor", "  ");
+						put("limit", "-1");
+					}
+				});
+		assertThat(validated.isValid()).isFalse();
+		ConstraintViolations violations = validated.errors();
+		assertThat(violations).hasSize(2);
+		assertThat(violations.get(0).name()).isEqualTo("cursor");
+		assertThat(violations.get(0).messageKey()).isEqualTo("charSequence.notBlank");
+		assertThat(violations.get(1).name()).isEqualTo("limit");
+		assertThat(violations.get(1).messageKey()).isEqualTo("numeric.positive");
+	}
+
+	@Test
+	void invalid_limit_over_limit() {
+		Validated<PaginationParam> validated = validator
+				.validate(new HashMap<String, String>() {
+					{
+						put("cursor", "  ");
+						put("limit", "1001");
+					}
+				});
+		assertThat(validated.isValid()).isFalse();
+		ConstraintViolations violations = validated.errors();
+		assertThat(violations).hasSize(2);
+		assertThat(violations.get(0).name()).isEqualTo("cursor");
+		assertThat(violations.get(0).messageKey()).isEqualTo("charSequence.notBlank");
+		assertThat(violations.get(1).name()).isEqualTo("limit");
+		assertThat(violations.get(1).messageKey()).isEqualTo("numeric.lessThanOrEqual");
+	}
+
+	@Test
+	void invalid_limit_not_integer() {
+		Validated<PaginationParam> validated = validator
+				.validate(new HashMap<String, String>() {
+					{
+						put("cursor", "  ");
+						put("limit", "abc");
+					}
+				});
+		assertThat(validated.isValid()).isFalse();
+		ConstraintViolations violations = validated.errors();
+		assertThat(violations).hasSize(2);
+		assertThat(violations.get(0).name()).isEqualTo("cursor");
+		assertThat(violations.get(0).messageKey()).isEqualTo("charSequence.notBlank");
+		assertThat(violations.get(1).name()).isEqualTo("limit");
+		assertThat(violations.get(1).messageKey()).isEqualTo("charSequence.integer");
+	}
+
+	public static class PaginationParam {
+		@Nullable
+		private final String cursor;
+
+		private final int maxPageSize;
+
+		public PaginationParam(@Nullable String cursor, int maxPageSize) {
+			this.cursor = cursor;
+			this.maxPageSize = maxPageSize;
+		}
+
+		@Nullable
+		public String cursor() {
+			return cursor;
+		}
+
+		public int maxPageSize() {
+			return maxPageSize;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof PaginationParam))
+				return false;
+			PaginationParam that = (PaginationParam) o;
+			return maxPageSize == that.maxPageSize && Objects.equals(cursor, that.cursor);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(cursor, maxPageSize);
+		}
+	}
+}


### PR DESCRIPTION
Corrected the order of type parameters when delegating to `ValueValidator` in ArgumentsValidatorBuilder from `ValueValidator<X, T>` to `ValueValidator<T, X>` to match the expected type constraints.

related to gh-286