### PR TITLE
Change the DSL build method to internal

### DIFF
--- a/src/main/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDsl.kt
+++ b/src/main/kotlin/am/ik/yavi/builder/ValidatorBuilderKtDsl.kt
@@ -36,7 +36,8 @@ inline fun <T> validator(init: ValidatorBuilderKt<T>.() -> Unit): Validator<T> {
 
 class ValidatorBuilderKt<T>(private val validatorBuilder: ValidatorBuilder<T>) {
 
-	fun build(): Validator<T> {
+	@PublishedApi
+	internal fun build(): Validator<T> {
 		return validatorBuilder.build()
 	}
 


### PR DESCRIPTION
## Motivation

Currently, it is possible to improperly access the `build` method in the DSL.
This method should ideally be inaccessible.

![CleanShot 2025-04-01 at 11 54 27](https://github.com/user-attachments/assets/633b6c47-0cf9-422a-9efe-5ebd64984398)

## What

I will change the `build` method to `internal`.  
However, since it needs to be called from an `inline` function, it is necessary to add the `@PublishedApi` annotation.

![CleanShot 2025-04-01 at 11 54 07](https://github.com/user-attachments/assets/18cd8b5b-907f-437a-9761-1f9c8b487c23)

## Note

Strictly speaking, this is a breaking change... but I think it might be acceptable.