### PR TITLE
Implement singleton pattern for SimpleMessageFormatter

### DIFF
--- a/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
+++ b/src/main/java/am/ik/yavi/builder/ValidatorBuilder.java
@@ -194,7 +194,8 @@ public class ValidatorBuilder<T> implements Cloneable {
 		return new Validator<>(messageKeySeparator,
 				new PredicatesList<>(this.conflictStrategy, this.predicatesList).toList(), this.collectionValidators,
 				this.conditionalValidators,
-				this.messageFormatter == null ? new SimpleMessageFormatter() : this.messageFormatter, this.failFast);
+				this.messageFormatter == null ? SimpleMessageFormatter.getInstance() : this.messageFormatter,
+				this.failFast);
 	}
 
 	/**

--- a/src/main/java/am/ik/yavi/message/SimpleMessageFormatter.java
+++ b/src/main/java/am/ik/yavi/message/SimpleMessageFormatter.java
@@ -28,7 +28,6 @@ public class SimpleMessageFormatter implements MessageFormatter {
 
 	/**
 	 * Returns the singleton instance of {@link SimpleMessageFormatter}.
-	 * 
 	 * @return the singleton instance
 	 */
 	public static SimpleMessageFormatter getInstance() {

--- a/src/main/java/am/ik/yavi/message/SimpleMessageFormatter.java
+++ b/src/main/java/am/ik/yavi/message/SimpleMessageFormatter.java
@@ -18,7 +18,32 @@ package am.ik.yavi.message;
 import java.text.MessageFormat;
 import java.util.Locale;
 
+/**
+ * A simple implementation of {@link MessageFormatter} that formats messages using
+ * {@link MessageFormat}. This class is a singleton to optimize resource usage.
+ */
 public class SimpleMessageFormatter implements MessageFormatter {
+
+	private static final SimpleMessageFormatter INSTANCE = new SimpleMessageFormatter();
+
+	/**
+	 * Returns the singleton instance of {@link SimpleMessageFormatter}.
+	 * 
+	 * @return the singleton instance
+	 */
+	public static SimpleMessageFormatter getInstance() {
+		return INSTANCE;
+	}
+
+	/**
+	 * Constructor.
+	 * @deprecated Use {@link #getInstance()} instead to get the singleton instance. This
+	 * constructor will be removed in a future version.
+	 */
+	@Deprecated
+	public SimpleMessageFormatter() {
+		// Public constructor kept for backward compatibility
+	}
 
 	@Override
 	public String format(String messageKey, String defaultMessageFormat, Object[] args, Locale locale) {

--- a/src/test/java/am/ik/yavi/core/BiConsumerTest.java
+++ b/src/test/java/am/ik/yavi/core/BiConsumerTest.java
@@ -33,7 +33,7 @@ class BiConsumerTest {
 
 	static final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
 			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					new SimpleMessageFormatter(), Locale.ENGLISH));
+					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
 
 	static final Validator<User> userValidator = ValidatorBuilder.of(User.class)
 		.constraint(User::getName, "name", c -> c.notNull().greaterThanOrEqual(1).lessThanOrEqual(20))

--- a/src/test/java/am/ik/yavi/core/BiValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/BiValidatorTest.java
@@ -33,7 +33,7 @@ class BiValidatorTest {
 
 	static final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
 			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					new SimpleMessageFormatter(), Locale.ENGLISH));
+					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
 
 	static final Validator<User> userValidator = ValidatorBuilder.of(User.class)
 		.constraint(User::getName, "name", c -> c.notNull().greaterThanOrEqual(1).lessThanOrEqual(20))

--- a/src/test/java/am/ik/yavi/core/ConstraintViolationsExceptionTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintViolationsExceptionTest.java
@@ -28,7 +28,7 @@ class ConstraintViolationsExceptionTest {
 	@Test
 	void customMessage() {
 		final ConstraintViolations violations = new ConstraintViolations();
-		final SimpleMessageFormatter messageFormatter = new SimpleMessageFormatter();
+		final SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
 		violations.add(new ConstraintViolation("name1", "key", "{0} is invalid.", new Object[] { "a" },
 				messageFormatter, Locale.ENGLISH));
 		final ConstraintViolationsException exception = new ConstraintViolationsException("error!", violations);
@@ -38,7 +38,7 @@ class ConstraintViolationsExceptionTest {
 	@Test
 	void defaultMessage() {
 		final ConstraintViolations violations = new ConstraintViolations();
-		final SimpleMessageFormatter messageFormatter = new SimpleMessageFormatter();
+		final SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
 		violations.add(new ConstraintViolation("name1", "key", "{0} is invalid.", new Object[] { "a" },
 				messageFormatter, Locale.ENGLISH));
 		final ConstraintViolationsException exception = new ConstraintViolationsException(violations);

--- a/src/test/java/am/ik/yavi/core/ConstraintViolationsTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintViolationsTest.java
@@ -27,7 +27,7 @@ public class ConstraintViolationsTest {
 
 	@Test
 	public void apply() {
-		SimpleMessageFormatter messageFormatter = new SimpleMessageFormatter();
+		SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
 		ConstraintViolations violations = new ConstraintViolations();
 		violations.add(new ConstraintViolation("foo0", "abc0", "hello0", new Object[] { 1 }, messageFormatter,
 				Locale.getDefault()));

--- a/src/test/java/am/ik/yavi/core/ValidatedTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatedTest.java
@@ -38,7 +38,7 @@ class ValidatedTest {
 	void failureWith() {
 		final Validated<Object> validated = Validated
 			.failureWith(new ConstraintViolation("name", "notNull", "\"{0}\" must not be blank.",
-					new Object[] { "name", "" }, new SimpleMessageFormatter(), Locale.ENGLISH));
+					new Object[] { "name", "" }, SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
 		assertThat(validated.isValid()).isFalse();
 		assertThat(validated.errors()).hasSize(1);
 		assertThat(validated.errors().get(0).message()).isEqualTo("\"name\" must not be blank.");
@@ -48,7 +48,7 @@ class ValidatedTest {
 	void testFailureWith() {
 		final Validated<Object> validated = Validated.failureWith(
 				Collections.singletonList(new ConstraintViolation("name", "notNull", "\"{0}\" must not be blank.",
-						new Object[] { "name", "" }, new SimpleMessageFormatter(), Locale.ENGLISH)));
+						new Object[] { "name", "" }, SimpleMessageFormatter.getInstance(), Locale.ENGLISH)));
 		assertThat(validated.isValid()).isFalse();
 		assertThat(validated.errors()).hasSize(1);
 		assertThat(validated.errors().get(0).message()).isEqualTo("\"name\" must not be blank.");

--- a/src/test/java/am/ik/yavi/factory/BiConsumerFactoryTest.java
+++ b/src/test/java/am/ik/yavi/factory/BiConsumerFactoryTest.java
@@ -32,7 +32,7 @@ class BiConsumerFactoryTest {
 
 	private final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
 			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					new SimpleMessageFormatter(), Locale.ENGLISH));
+					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
 
 	private final BiConsumerFactory<List<ConstraintViolation>> validatorFactory = new BiConsumerFactory<>(
 			this.errorHandler);

--- a/src/test/java/am/ik/yavi/factory/BiValidatorFactoryTest.java
+++ b/src/test/java/am/ik/yavi/factory/BiValidatorFactoryTest.java
@@ -32,7 +32,7 @@ class BiValidatorFactoryTest {
 
 	private final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
 			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					new SimpleMessageFormatter(), Locale.ENGLISH));
+					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
 
 	private final BiValidatorFactory<List<ConstraintViolation>> validatorFactory = new BiValidatorFactory<>(
 			this.errorHandler);


### PR DESCRIPTION
## Summary
- Add singleton pattern to SimpleMessageFormatter to optimize resource usage
- Keep backward compatibility with deprecated public constructor
- Update all usages in the codebase to use getInstance() method

## Implementation details
- Added a private static final instance in SimpleMessageFormatter
- Added a public getInstance() static method to access the singleton
- Deprecated the public constructor while keeping it for backward compatibility
- Updated ValidatorBuilder to use singleton instance
- Updated all test files to use SimpleMessageFormatter.getInstance()
- Added appropriate Javadoc documentation

This change should help with resource optimization while maintaining backward compatibility with existing code, allowing for a gradual migration to the singleton pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)
