### PR TITLE
Add builder pattern to ConstraintViolation

### DIFF
--- a/src/main/java/am/ik/yavi/core/ConstraintViolation.java
+++ b/src/main/java/am/ik/yavi/core/ConstraintViolation.java
@@ -15,11 +15,12 @@
  */
 package am.ik.yavi.core;
 
+import am.ik.yavi.jsr305.Nullable;
+import am.ik.yavi.message.MessageFormatter;
+import am.ik.yavi.message.SimpleMessageFormatter;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.function.Function;
-
-import am.ik.yavi.message.MessageFormatter;
 
 public class ConstraintViolation {
 
@@ -35,14 +36,26 @@ public class ConstraintViolation {
 
 	private final String name;
 
-	public ConstraintViolation(String name, String messageKey, String defaultMessageFormat, Object[] args,
-			MessageFormatter messageFormatter, Locale locale) {
+	/**
+	 * Creates a new constraint violation.
+	 * @param name the field or property name that this constraint violation applies to
+	 * @param messageKey the key used to look up localized messages
+	 * @param defaultMessageFormat the default message format to use when no localized
+	 * message is found
+	 * @param args the arguments to be used when formatting the message
+	 * @param messageFormatter the message formatter to be used
+	 * @param locale the locale to be used for message localization
+	 * @deprecated Use {@link #builder()} instead for a more fluent and type-safe API
+	 */
+	@Deprecated
+	public ConstraintViolation(String name, String messageKey, String defaultMessageFormat, @Nullable Object[] args,
+			@Nullable MessageFormatter messageFormatter, @Nullable Locale locale) {
 		this.name = name;
 		this.messageKey = messageKey;
 		this.defaultMessageFormat = defaultMessageFormat;
-		this.args = args;
-		this.messageFormatter = messageFormatter;
-		this.locale = locale;
+		this.args = args == null ? new Object[0] : args;
+		this.messageFormatter = messageFormatter == null ? SimpleMessageFormatter.getInstance() : messageFormatter;
+		this.locale = locale == null ? Locale.getDefault() : locale;
 	}
 
 	public Object[] args() {
@@ -84,6 +97,11 @@ public class ConstraintViolation {
 	}
 
 	/**
+	 * Returns a new ConstraintViolation with the name transformed using the provided
+	 * function. If the arguments array is not empty, the first element will be updated
+	 * with the new name.
+	 * @param rename the function to transform the current name
+	 * @return a new ConstraintViolation with the renamed name
 	 * @since 0.7.0
 	 */
 	public ConstraintViolation rename(Function<? super String, String> rename) {
@@ -97,10 +115,332 @@ public class ConstraintViolation {
 	}
 
 	/**
+	 * Returns a new ConstraintViolation with the name indexed by appending "[index]" to
+	 * the current name.
+	 * @param index the index to append to the name
+	 * @return a new ConstraintViolation with the indexed name
 	 * @since 0.7.0
 	 */
 	public ConstraintViolation indexed(int index) {
 		return this.rename(name -> name + "[" + index + "]");
+	}
+
+	/**
+	 * Creates a new builder for constructing ConstraintViolation instances using a
+	 * fluent, type-safe API. This builder implements a staged builder pattern to enforce
+	 * required properties while making optional properties truly optional.
+	 * @return the first stage of the builder which requires setting the name property
+	 * @since 0.15.0
+	 */
+	public static StagedBuilders.Name builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Implementation of the staged builder pattern for creating ConstraintViolation
+	 * instances. This builder class implements all the staged interfaces to provide a
+	 * fluent and type-safe way to construct ConstraintViolation objects.
+	 *
+	 * @since 0.15.0
+	 */
+	public static class Builder implements StagedBuilders.Name, StagedBuilders.MessageKey,
+			StagedBuilders.DefaultMessageFormat, StagedBuilders.Optionals {
+
+		/** The field name that the constraint violation applies to */
+		private String name;
+
+		/** The message key for internationalization */
+		private String messageKey;
+
+		/** The default message format if no localized message is found */
+		private String defaultMessageFormat;
+
+		/** The arguments to be used when formatting the message */
+		private Object[] args;
+
+		/** The message formatter to be used for formatting the message */
+		private MessageFormatter messageFormatter;
+
+		/** The locale to be used for message localization */
+		private Locale locale;
+
+		/**
+		 * Private constructor to prevent direct instantiation. Use
+		 * {@link ConstraintViolation#builder()} instead.
+		 */
+		private Builder() {
+		}
+
+		/**
+		 * Sets the name of the field or property that this constraint violation applies
+		 * to.
+		 * @param name the field or property name
+		 * @return the next stage of the builder for method chaining
+		 */
+		public Builder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Sets the message key for internationalization lookup.
+		 * @param messageKey the key used to look up localized messages
+		 * @return the next stage of the builder for method chaining
+		 */
+		public Builder messageKey(String messageKey) {
+			this.messageKey = messageKey;
+			return this;
+		}
+
+		/**
+		 * Sets the default message format to use when no localized message is found.
+		 * @param defaultMessageFormat the default message format string
+		 * @return the next stage of the builder for method chaining
+		 */
+		public Builder defaultMessageFormat(String defaultMessageFormat) {
+			this.defaultMessageFormat = defaultMessageFormat;
+			return this;
+		}
+
+		/**
+		 * Sets the arguments to be used when formatting the message.
+		 * @param args the arguments to be used in message formatting
+		 * @return this builder for method chaining
+		 */
+		public Builder args(Object... args) {
+			this.args = args;
+			return this;
+		}
+
+		/**
+		 * Sets the arguments to be used when formatting the message, automatically
+		 * including the name as the first argument.
+		 * 
+		 * This method is more convenient than {@link #args(Object...)} when the name
+		 * needs to be the first argument in the message, which is a common pattern for
+		 * constraint violations.
+		 * @param args the arguments to be used in message formatting (excluding the name)
+		 * @return this builder for method chaining
+		 */
+		public Builder argsWithPrependedName(Object... args) {
+			Object[] argsWithName = new Object[args.length + 1];
+			argsWithName[0] = this.name;
+			System.arraycopy(args, 0, argsWithName, 1, args.length);
+			this.args = argsWithName;
+			return this;
+		}
+
+		/**
+		 * Sets the arguments to be used when formatting the message, automatically
+		 * prepending the name as the first argument and appending the violatedValue as
+		 * the last argument.
+		 * 
+		 * This method provides a complete solution for the most common constraint
+		 * violation formatting pattern by automatically handling both the name and
+		 * violated value positioning.
+		 * @param args optional arguments to be used in message formatting (excluding both
+		 * name and violated value)
+		 * @param violatedValue the value object that violated the constraint, actual
+		 * value is retrieved by calling value() method
+		 * @return this builder for method chaining
+		 */
+		public Builder argsWithPrependedNameAndAppendedViolatedValue(Object[] args, ViolatedValue violatedValue) {
+			Object[] completeArgs = new Object[args.length + 2];
+			completeArgs[0] = this.name;
+			System.arraycopy(args, 0, completeArgs, 1, args.length);
+			completeArgs[args.length + 1] = violatedValue.value();
+			this.args = completeArgs;
+			return this;
+		}
+
+		/**
+		 * Sets the message formatter to be used for message formatting. If not specified,
+		 * a default {@link SimpleMessageFormatter} will be used.
+		 * @param messageFormatter the message formatter to use
+		 * @return this builder for method chaining
+		 */
+		public Builder messageFormatter(MessageFormatter messageFormatter) {
+			this.messageFormatter = messageFormatter;
+			return this;
+		}
+
+		/**
+		 * Sets the locale to be used for message localization. If not specified, the
+		 * system default locale will be used.
+		 * @param locale the locale to use for message localization
+		 * @return this builder for method chaining
+		 */
+		public Builder locale(Locale locale) {
+			this.locale = locale;
+			return this;
+		}
+
+		/**
+		 * Builds a new {@link ConstraintViolation} instance with the configured
+		 * properties.
+		 * @return a new {@link ConstraintViolation} instance
+		 */
+		public ConstraintViolation build() {
+			return new ConstraintViolation(name, messageKey, defaultMessageFormat, args, messageFormatter, locale);
+		}
+
+	}
+
+	/**
+	 * Container interface for the staged builder interfaces. This interface hierarchy
+	 * enables a type-safe builder pattern that enforces required properties to be set in
+	 * a specific order before optional properties.
+	 *
+	 * @since 0.15.0
+	 */
+	public interface StagedBuilders {
+
+		/**
+		 * First stage of the builder which requires setting the name property.
+		 */
+		interface Name {
+
+			/**
+			 * Sets the name of the field or property that this constraint violation
+			 * applies to.
+			 * @param name the field or property name
+			 * @return the next stage of the builder which requires setting the message
+			 * key
+			 */
+			MessageKey name(String name);
+
+		}
+
+		/**
+		 * Second stage of the builder which requires setting the message key property.
+		 */
+		interface MessageKey {
+
+			String DEFAULT_MESSAGE_KEY = "_";
+
+			/**
+			 * Sets the message key for internationalization lookup.
+			 * @param messageKey the key used to look up localized messages
+			 * @return the next stage of the builder which requires setting the default
+			 * message format
+			 */
+			DefaultMessageFormat messageKey(String messageKey);
+
+			/**
+			 * Convenient shortcut builder method that creates a complete constraint
+			 * violation in a single call. This method automatically:
+			 * <ul>
+			 * <li>Sets the message key to the default value
+			 * ({@link #DEFAULT_MESSAGE_KEY})</li>
+			 * <li>Uses the provided message as the default message format</li>
+			 * <li>Prepends the field name as the first argument in the argument list</li>
+			 * <li>Builds and returns the final ConstraintViolation object</li>
+			 * </ul>
+			 * 
+			 * <p>
+			 * This method is particularly useful for simple constraint violations where
+			 * complex message formatting or internationalization is not required.
+			 * @param message the message text to be used as the default message format
+			 * @return a fully constructed {@link ConstraintViolation} instance with the
+			 * specified message
+			 * @since 0.15.0
+			 */
+			default ConstraintViolation message(String message) {
+				return this.messageKey(DEFAULT_MESSAGE_KEY)
+					.defaultMessageFormat(message)
+					.argsWithPrependedName()
+					.build();
+			}
+
+		}
+
+		/**
+		 * Third stage of the builder which requires setting the default message format
+		 * property.
+		 */
+		interface DefaultMessageFormat {
+
+			/**
+			 * Sets the default message format to use when no localized message is found.
+			 * @param defaultMessageFormat the default message format string
+			 * @return the final stage of the builder where all remaining properties are
+			 * optional
+			 */
+			Optionals defaultMessageFormat(String defaultMessageFormat);
+
+		}
+
+		/**
+		 * Final stage of the builder where all remaining properties are optional. The
+		 * build() method can be called at any point from this stage.
+		 */
+		interface Optionals {
+
+			/**
+			 * Sets the arguments to be used when formatting the message.
+			 * @param args the arguments to be used in message formatting
+			 * @return this builder for method chaining
+			 */
+			Optionals args(Object... args);
+
+			/**
+			 * Sets the arguments to be used when formatting the message, automatically
+			 * including the name as the first argument.
+			 * 
+			 * This method is more convenient than {@link #args(Object...)} when the name
+			 * needs to be the first argument in the message, which is a common pattern
+			 * for constraint violations.
+			 * @param args the arguments to be used in message formatting (excluding the
+			 * name)
+			 * @return this builder for method chaining
+			 */
+			Optionals argsWithPrependedName(Object... args);
+
+			/**
+			 * Sets the arguments to be used when formatting the message, automatically
+			 * prepending the name as the first argument and appending the violatedValue
+			 * as the last argument.
+			 * 
+			 * This method provides a complete solution for the most common constraint
+			 * violation formatting pattern by automatically handling both the name and
+			 * violated value positioning.
+			 * @param args optional arguments to be used in message formatting (excluding
+			 * both name and violated value)
+			 * @param violatedValue the value object that violated the constraint, actual
+			 * value is retrieved by calling value() method
+			 * @return this builder for method chaining
+			 */
+			Optionals argsWithPrependedNameAndAppendedViolatedValue(Object[] args, ViolatedValue violatedValue);
+
+			/**
+			 * Sets the message formatter to be used for message formatting. If not
+			 * prepending the name as the first argument and appending the violatedValue
+			 * as the last argument.
+			 * 
+			 * This method provides a complete solution for the most common constraint
+			 * violation formatting pattern by automatically handling both the name and
+			 * violated value positioning.
+			 * @return this builder for method chaining
+			 */
+			Optionals messageFormatter(MessageFormatter messageFormatter);
+
+			/**
+			 * Sets the locale to be used for message localization. If not specified, the
+			 * system default locale will be used.
+			 * @param locale the locale to use for message localization
+			 * @return this builder for method chaining
+			 */
+			Optionals locale(Locale locale);
+
+			/**
+			 * Builds a new {@link ConstraintViolation} instance with the configured
+			 * properties.
+			 * @return a new {@link ConstraintViolation} instance
+			 */
+			ConstraintViolation build();
+
+		}
+
 	}
 
 }

--- a/src/test/java/am/ik/yavi/core/BiConsumerTest.java
+++ b/src/test/java/am/ik/yavi/core/BiConsumerTest.java
@@ -15,15 +15,12 @@
  */
 package am.ik.yavi.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
-
 import am.ik.yavi.User;
 import am.ik.yavi.builder.ValidatorBuilder;
-import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -32,8 +29,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BiConsumerTest {
 
 	static final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
-			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
+			defaultMessage) -> errors.add(ConstraintViolation.builder()
+				.name(name)
+				.messageKey(messageKey)
+				.defaultMessageFormat(defaultMessage)
+				.args(args)
+				.build());
 
 	static final Validator<User> userValidator = ValidatorBuilder.of(User.class)
 		.constraint(User::getName, "name", c -> c.notNull().greaterThanOrEqual(1).lessThanOrEqual(20))

--- a/src/test/java/am/ik/yavi/core/BiValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/BiValidatorTest.java
@@ -15,15 +15,12 @@
  */
 package am.ik.yavi.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Stream;
-
 import am.ik.yavi.User;
 import am.ik.yavi.builder.ValidatorBuilder;
 import am.ik.yavi.core.BiValidator.ErrorHandler;
-import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -32,8 +29,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BiValidatorTest {
 
 	static final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
-			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
+			defaultMessage) -> errors.add(ConstraintViolation.builder()
+				.name(name)
+				.messageKey(messageKey)
+				.defaultMessageFormat(defaultMessage)
+				.args(args)
+				.build());
 
 	static final Validator<User> userValidator = ValidatorBuilder.of(User.class)
 		.constraint(User::getName, "name", c -> c.notNull().greaterThanOrEqual(1).lessThanOrEqual(20))

--- a/src/test/java/am/ik/yavi/core/ConstraintViolationTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintViolationTest.java
@@ -1,0 +1,154 @@
+package am.ik.yavi.core;
+
+import am.ik.yavi.message.MessageFormatter;
+import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConstraintViolation} class and its builder pattern.
+ */
+class ConstraintViolationTest {
+
+	@Test
+	void testBasicBuilder() {
+		// Test basic builder with only required properties
+		String name = "username";
+		String messageKey = "length";
+		String defaultMessage = "{0} length must be between {1} and {2}";
+
+		ConstraintViolation violation = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.build();
+
+		assertThat(violation.name()).isEqualTo(name);
+		assertThat(violation.messageKey()).isEqualTo(messageKey);
+		assertThat(violation.defaultMessageFormat()).isEqualTo(defaultMessage);
+		assertThat(violation.args()).isNotNull();
+		assertThat(violation.args()).isEmpty();
+		assertThat(violation.locale()).isEqualTo(Locale.getDefault());
+		assertThat(violation.message()).isEqualTo(defaultMessage);
+	}
+
+	@Test
+	void testBuilderWithAllOptions() {
+		// Test builder with all options
+		String name = "username";
+		String messageKey = "length";
+		String defaultMessage = "{0} length must be between {1} and {2}";
+		Object[] args = new Object[] { name, 4, 20 };
+		MessageFormatter formatter = SimpleMessageFormatter.getInstance();
+		Locale locale = Locale.ENGLISH;
+
+		ConstraintViolation violation = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.args(args)
+			.messageFormatter(formatter)
+			.locale(locale)
+			.build();
+
+		assertThat(violation.name()).isEqualTo(name);
+		assertThat(violation.messageKey()).isEqualTo(messageKey);
+		assertThat(violation.defaultMessageFormat()).isEqualTo(defaultMessage);
+		assertThat(violation.args()).isEqualTo(args);
+		assertThat(violation.locale()).isEqualTo(locale);
+		assertThat(violation.message()).isEqualTo("username length must be between 4 and 20");
+	}
+
+	@Test
+	void testArgsWithPrependedName() {
+		// Test argsWithPrependedName method
+		String name = "username";
+		String messageKey = "length";
+		String defaultMessage = "{0} length must be between {1} and {2}";
+
+		ConstraintViolation violation = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.argsWithPrependedName(4, 20) // Varargs
+			.locale(Locale.ENGLISH)
+			.build();
+
+		assertThat(violation.args()).hasSize(3);
+		assertThat(violation.args()[0]).isEqualTo(name);
+		assertThat(violation.args()[1]).isEqualTo(4);
+		assertThat(violation.args()[2]).isEqualTo(20);
+		assertThat(violation.message()).isEqualTo("username length must be between 4 and 20");
+	}
+
+	@Test
+	void testArgsWithPrependedNameAndAppendedViolatedValue() {
+		// Test argsWithPrependedNameAndAppendedViolatedValue method
+		String name = "username";
+		String messageKey = "length";
+		String defaultMessage = "{0} length must be between {1} and {2}, but was {3}";
+		String invalidValue = "abc"; // Too short value
+		ViolatedValue violatedValue = new ViolatedValue(invalidValue);
+		Object[] middleArgs = new Object[] { 4, 20 };
+
+		ConstraintViolation violation = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.argsWithPrependedNameAndAppendedViolatedValue(middleArgs, violatedValue)
+			.locale(Locale.ENGLISH)
+			.build();
+
+		assertThat(violation.args()).hasSize(4);
+		assertThat(violation.args()[0]).isEqualTo(name);
+		assertThat(violation.args()[1]).isEqualTo(4);
+		assertThat(violation.args()[2]).isEqualTo(20);
+		assertThat(violation.args()[3]).isEqualTo(invalidValue);
+		assertThat(violation.message()).isEqualTo("username length must be between 4 and 20, but was abc");
+	}
+
+	@Test
+	void testRename() {
+		// Test rename method
+		String name = "username";
+		String messageKey = "length";
+		String defaultMessage = "{0} length must be between {1} and {2}";
+
+		ConstraintViolation original = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.argsWithPrependedName(4, 20)
+			.build();
+
+		ConstraintViolation renamed = original.rename(n -> "user." + n);
+
+		assertThat(renamed.name()).isEqualTo("user.username");
+		assertThat(renamed.args()[0]).isEqualTo("user.username");
+		assertThat(renamed.message()).contains("user.username");
+	}
+
+	@Test
+	void testIndexed() {
+		// Test indexed method
+		String name = "items";
+		String messageKey = "notEmpty";
+		String defaultMessage = "{0} must not be empty";
+
+		ConstraintViolation original = ConstraintViolation.builder()
+			.name(name)
+			.messageKey(messageKey)
+			.defaultMessageFormat(defaultMessage)
+			.argsWithPrependedName()
+			.build();
+
+		ConstraintViolation indexed = original.indexed(3);
+
+		assertThat(indexed.name()).isEqualTo("items[3]");
+		assertThat(indexed.args()[0]).isEqualTo("items[3]");
+		assertThat(indexed.message()).isEqualTo("items[3] must not be empty");
+	}
+
+}

--- a/src/test/java/am/ik/yavi/core/ConstraintViolationsExceptionTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintViolationsExceptionTest.java
@@ -15,22 +15,16 @@
  */
 package am.ik.yavi.core;
 
-import java.util.Locale;
-
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import am.ik.yavi.message.SimpleMessageFormatter;
 
 class ConstraintViolationsExceptionTest {
 
 	@Test
 	void customMessage() {
 		final ConstraintViolations violations = new ConstraintViolations();
-		final SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
-		violations.add(new ConstraintViolation("name1", "key", "{0} is invalid.", new Object[] { "a" },
-				messageFormatter, Locale.ENGLISH));
+		violations.add(ConstraintViolation.builder().name("name1").message("a is invalid."));
 		final ConstraintViolationsException exception = new ConstraintViolationsException("error!", violations);
 		assertThat(exception.getMessage()).isEqualTo("error!");
 	}
@@ -38,9 +32,7 @@ class ConstraintViolationsExceptionTest {
 	@Test
 	void defaultMessage() {
 		final ConstraintViolations violations = new ConstraintViolations();
-		final SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
-		violations.add(new ConstraintViolation("name1", "key", "{0} is invalid.", new Object[] { "a" },
-				messageFormatter, Locale.ENGLISH));
+		violations.add(ConstraintViolation.builder().name("name1").message("a is invalid."));
 		final ConstraintViolationsException exception = new ConstraintViolationsException(violations);
 		assertThat(exception.getMessage())
 			.isEqualTo("Constraint violations found!" + System.lineSeparator() + "* a is invalid.");

--- a/src/test/java/am/ik/yavi/core/ConstraintViolationsTest.java
+++ b/src/test/java/am/ik/yavi/core/ConstraintViolationsTest.java
@@ -15,10 +15,8 @@
  */
 package am.ik.yavi.core;
 
-import java.util.Arrays;
-import java.util.Locale;
-
 import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,11 +27,20 @@ public class ConstraintViolationsTest {
 	public void apply() {
 		SimpleMessageFormatter messageFormatter = SimpleMessageFormatter.getInstance();
 		ConstraintViolations violations = new ConstraintViolations();
-		violations.add(new ConstraintViolation("foo0", "abc0", "hello0", new Object[] { 1 }, messageFormatter,
-				Locale.getDefault()));
-		violations.add(new ConstraintViolation("foo1", "abc1", "hello1", new Object[] { 1 }, messageFormatter,
-				Locale.getDefault()));
-
+		violations.add(ConstraintViolation.builder()
+			.name("foo0")
+			.messageKey("abc0")
+			.defaultMessageFormat("hello0")
+			.args(1)
+			.messageFormatter(messageFormatter)
+			.build());
+		violations.add(ConstraintViolation.builder()
+			.name("foo1")
+			.messageKey("abc1")
+			.defaultMessageFormat("hello1")
+			.args(1)
+			.messageFormatter(messageFormatter)
+			.build());
 		BindingResult bindingResult = new BindingResult();
 		violations.apply(bindingResult::rejectValue);
 		assertThat(bindingResult.toString()).isEqualTo("[foo0_abc0_[1]_hello0][foo1_abc1_[1]_hello1]");

--- a/src/test/java/am/ik/yavi/core/ValidatedTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatedTest.java
@@ -16,14 +16,9 @@
 package am.ik.yavi.core;
 
 import java.util.Collections;
-import java.util.Locale;
-
-import am.ik.yavi.message.SimpleMessageFormatter;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class ValidatedTest {
 
@@ -37,8 +32,7 @@ class ValidatedTest {
 	@Test
 	void failureWith() {
 		final Validated<Object> validated = Validated
-			.failureWith(new ConstraintViolation("name", "notNull", "\"{0}\" must not be blank.",
-					new Object[] { "name", "" }, SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
+			.failureWith(ConstraintViolation.builder().name("name").message("\"{0}\" must not be blank."));
 		assertThat(validated.isValid()).isFalse();
 		assertThat(validated.errors()).hasSize(1);
 		assertThat(validated.errors().get(0).message()).isEqualTo("\"name\" must not be blank.");
@@ -46,9 +40,8 @@ class ValidatedTest {
 
 	@Test
 	void testFailureWith() {
-		final Validated<Object> validated = Validated.failureWith(
-				Collections.singletonList(new ConstraintViolation("name", "notNull", "\"{0}\" must not be blank.",
-						new Object[] { "name", "" }, SimpleMessageFormatter.getInstance(), Locale.ENGLISH)));
+		final Validated<Object> validated = Validated.failureWith(Collections
+			.singletonList(ConstraintViolation.builder().name("name").message("\"{0}\" must not be blank.")));
 		assertThat(validated.isValid()).isFalse();
 		assertThat(validated.errors()).hasSize(1);
 		assertThat(validated.errors().get(0).message()).isEqualTo("\"name\" must not be blank.");

--- a/src/test/java/am/ik/yavi/factory/BiConsumerFactoryTest.java
+++ b/src/test/java/am/ik/yavi/factory/BiConsumerFactoryTest.java
@@ -15,15 +15,12 @@
  */
 package am.ik.yavi.factory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.function.BiConsumer;
-
 import am.ik.yavi.User;
 import am.ik.yavi.core.ConstraintViolation;
 import am.ik.yavi.core.ErrorHandler;
-import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,8 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BiConsumerFactoryTest {
 
 	private final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
-			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
+			defaultMessage) -> errors.add(ConstraintViolation.builder()
+				.name(name)
+				.messageKey(messageKey)
+				.defaultMessageFormat(defaultMessage)
+				.args(args)
+				.build());
 
 	private final BiConsumerFactory<List<ConstraintViolation>> validatorFactory = new BiConsumerFactory<>(
 			this.errorHandler);

--- a/src/test/java/am/ik/yavi/factory/BiValidatorFactoryTest.java
+++ b/src/test/java/am/ik/yavi/factory/BiValidatorFactoryTest.java
@@ -15,15 +15,12 @@
  */
 package am.ik.yavi.factory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
 import am.ik.yavi.User;
 import am.ik.yavi.core.BiValidator;
 import am.ik.yavi.core.BiValidator.ErrorHandler;
 import am.ik.yavi.core.ConstraintViolation;
-import am.ik.yavi.message.SimpleMessageFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,8 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BiValidatorFactoryTest {
 
 	private final ErrorHandler<List<ConstraintViolation>> errorHandler = (errors, name, messageKey, args,
-			defaultMessage) -> errors.add(new ConstraintViolation(name, messageKey, defaultMessage, args,
-					SimpleMessageFormatter.getInstance(), Locale.ENGLISH));
+			defaultMessage) -> errors.add(ConstraintViolation.builder()
+				.name(name)
+				.messageKey(messageKey)
+				.defaultMessageFormat(defaultMessage)
+				.args(args)
+				.build());
 
 	private final BiValidatorFactory<List<ConstraintViolation>> validatorFactory = new BiValidatorFactory<>(
 			this.errorHandler);


### PR DESCRIPTION
## Summary
This PR introduces a staged builder pattern for the ConstraintViolation class to provide a more fluent and type-safe API for creating constraint violations.

## Changes
- Add StagedBuilders interface hierarchy to enforce required properties
- Implement a fluent Builder class with various convenience methods
- Make existing constructor deprecated in favor of the builder
- Add null-safety with @Nullable annotations and fallback defaults
- Add comprehensive JavaDoc to all new methods
- Create tests for all builder pattern functionality

The new API makes it easier to create properly configured constraint violations while ensuring type safety and required properties.