### PR TITLE
Rename ValueValidator#andThen to map for better semantic clarity

### DIFF
--- a/scripts/generate-args.sh
+++ b/scripts/generate-args.sh
@@ -665,9 +665,23 @@ fi)
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */$(if [ "${i}" == "1" ];then echo;echo "	@Override"; fi)
+	@Deprecated
 	default <X2> ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */$(if [ "${i}" == "1" ];then echo;echo "	@Override"; fi)
+	default <X2> ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), X2> map(Function<? super X, ? extends X2> mapper) {
 		return new ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), X2>() {
 			@Override
 			public Validated<X2> validate($(echo $(for j in `seq 1 ${i}`;do echo -n "A${j} a${j}, ";done) | sed 's/,$//'), Locale locale, ConstraintContext constraintContext) {
@@ -677,7 +691,7 @@ fi)
 			@Override
 			public ${class}<$(echo $(for j in `seq 1 ${i}`;do echo -n "A${j}, ";done) | sed 's/,$//'), Supplier<X2>> lazy() {
 				return ${class}.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments10Validator.java
@@ -100,9 +100,24 @@ public interface Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X2>() {
 			@Override
@@ -116,7 +131,7 @@ public interface Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, X
 			@Override
 			public Arguments10Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Supplier<X2>> lazy() {
 				return Arguments10Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments11Validator.java
@@ -102,9 +102,24 @@ public interface Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, X2>() {
 			@Override
@@ -118,7 +133,7 @@ public interface Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments11Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Supplier<X2>> lazy() {
 				return Arguments11Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments12Validator.java
@@ -104,9 +104,24 @@ public interface Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, X2>() {
 			@Override
@@ -120,7 +135,7 @@ public interface Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments12Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Supplier<X2>> lazy() {
 				return Arguments12Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments13Validator.java
@@ -105,9 +105,24 @@ public interface Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, X2>() {
 			@Override
@@ -121,7 +136,7 @@ public interface Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments13Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Supplier<X2>> lazy() {
 				return Arguments13Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments14Validator.java
@@ -107,9 +107,24 @@ public interface Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, X2>() {
 			@Override
@@ -123,7 +138,7 @@ public interface Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments14Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Supplier<X2>> lazy() {
 				return Arguments14Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments15Validator.java
@@ -111,9 +111,24 @@ public interface Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, X2>() {
 			@Override
@@ -128,7 +143,7 @@ public interface Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments15Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Supplier<X2>> lazy() {
 				return Arguments15Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments16Validator.java
@@ -112,9 +112,24 @@ public interface Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, X2>() {
 			@Override
@@ -130,7 +145,7 @@ public interface Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 			@Override
 			public Arguments16Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, Supplier<X2>> lazy() {
 				return Arguments16Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments1Validator.java
@@ -110,10 +110,25 @@ public interface Arguments1Validator<A1, X> extends ValueValidator<A1, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
 	@Override
+	@Deprecated
 	default <X2> Arguments1Validator<A1, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	@Override
+	default <X2> Arguments1Validator<A1, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments1Validator<A1, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, Locale locale, ConstraintContext constraintContext) {
@@ -123,7 +138,7 @@ public interface Arguments1Validator<A1, X> extends ValueValidator<A1, X> {
 			@Override
 			public Arguments1Validator<A1, Supplier<X2>> lazy() {
 				return Arguments1Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments2Validator.java
@@ -83,9 +83,23 @@ public interface Arguments2Validator<A1, A2, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments2Validator<A1, A2, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments2Validator<A1, A2, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments2Validator<A1, A2, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, Locale locale, ConstraintContext constraintContext) {
@@ -95,7 +109,7 @@ public interface Arguments2Validator<A1, A2, X> {
 			@Override
 			public Arguments2Validator<A1, A2, Supplier<X2>> lazy() {
 				return Arguments2Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments3Validator.java
@@ -87,9 +87,23 @@ public interface Arguments3Validator<A1, A2, A3, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments3Validator<A1, A2, A3, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments3Validator<A1, A2, A3, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments3Validator<A1, A2, A3, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, Locale locale, ConstraintContext constraintContext) {
@@ -99,7 +113,7 @@ public interface Arguments3Validator<A1, A2, A3, X> {
 			@Override
 			public Arguments3Validator<A1, A2, A3, Supplier<X2>> lazy() {
 				return Arguments3Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments4Validator.java
@@ -89,9 +89,23 @@ public interface Arguments4Validator<A1, A2, A3, A4, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments4Validator<A1, A2, A3, A4, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments4Validator<A1, A2, A3, A4, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments4Validator<A1, A2, A3, A4, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, A4 a4, Locale locale,
@@ -102,7 +116,7 @@ public interface Arguments4Validator<A1, A2, A3, A4, X> {
 			@Override
 			public Arguments4Validator<A1, A2, A3, A4, Supplier<X2>> lazy() {
 				return Arguments4Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments5Validator.java
@@ -90,9 +90,23 @@ public interface Arguments5Validator<A1, A2, A3, A4, A5, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments5Validator<A1, A2, A3, A4, A5, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments5Validator<A1, A2, A3, A4, A5, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments5Validator<A1, A2, A3, A4, A5, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, Locale locale,
@@ -103,7 +117,7 @@ public interface Arguments5Validator<A1, A2, A3, A4, A5, X> {
 			@Override
 			public Arguments5Validator<A1, A2, A3, A4, A5, Supplier<X2>> lazy() {
 				return Arguments5Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments6Validator.java
@@ -91,9 +91,23 @@ public interface Arguments6Validator<A1, A2, A3, A4, A5, A6, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments6Validator<A1, A2, A3, A4, A5, A6, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments6Validator<A1, A2, A3, A4, A5, A6, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments6Validator<A1, A2, A3, A4, A5, A6, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, Locale locale,
@@ -104,7 +118,7 @@ public interface Arguments6Validator<A1, A2, A3, A4, A5, A6, X> {
 			@Override
 			public Arguments6Validator<A1, A2, A3, A4, A5, A6, Supplier<X2>> lazy() {
 				return Arguments6Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments7Validator.java
@@ -94,9 +94,23 @@ public interface Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, Locale locale,
@@ -108,7 +122,7 @@ public interface Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, X> {
 			@Override
 			public Arguments7Validator<A1, A2, A3, A4, A5, A6, A7, Supplier<X2>> lazy() {
 				return Arguments7Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments8Validator.java
@@ -95,10 +95,24 @@ public interface Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X2> andThen(
 			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X2> map(Function<? super X, ? extends X2> mapper) {
 		return new Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X2>() {
 			@Override
 			public Validated<X2> validate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, Locale locale,
@@ -110,7 +124,7 @@ public interface Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, X> {
 			@Override
 			public Arguments8Validator<A1, A2, A3, A4, A5, A6, A7, A8, Supplier<X2>> lazy() {
 				return Arguments8Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
+++ b/src/main/java/am/ik/yavi/arguments/Arguments9Validator.java
@@ -97,9 +97,24 @@ public interface Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X> {
 	}
 
 	/**
+	 * @deprecated Use {@link #map(Function)} instead.
 	 * @since 0.7.0
 	 */
+	@Deprecated
 	default <X2> Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X2> andThen(
+			Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X2> map(
 			Function<? super X, ? extends X2> mapper) {
 		return new Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X2>() {
 			@Override
@@ -112,7 +127,7 @@ public interface Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, X> {
 			@Override
 			public Arguments9Validator<A1, A2, A3, A4, A5, A6, A7, A8, A9, Supplier<X2>> lazy() {
 				return Arguments9Validator.this.lazy()
-					.andThen((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
+					.map((Function<Supplier<X>, Supplier<X2>>) xSupplier -> () -> mapper.apply(xSupplier.get()));
 			}
 		};
 	}

--- a/src/main/java/am/ik/yavi/arguments/BigDecimalValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/BigDecimalValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class BigDecimalValidator<T> extends DefaultArguments1Validator<BigDecimal, T> {
 
 	@Override
-	public <T2> BigDecimalValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> BigDecimalValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new BigDecimalValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/BigIntegerValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/BigIntegerValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class BigIntegerValidator<T> extends DefaultArguments1Validator<BigInteger, T> {
 
 	@Override
-	public <T2> BigIntegerValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> BigIntegerValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new BigIntegerValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/BooleanValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/BooleanValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class BooleanValidator<T> extends DefaultArguments1Validator<Boolean, T> {
 
 	@Override
-	public <T2> BooleanValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> BooleanValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new BooleanValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/DoubleValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/DoubleValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class DoubleValidator<T> extends DefaultArguments1Validator<Double, T> {
 
 	@Override
-	public <T2> DoubleValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> DoubleValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new DoubleValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/EnumValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/EnumValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class EnumValidator<E extends Enum<E>, T> extends DefaultArguments1Validator<E, T> {
 
 	@Override
-	public <T2> EnumValidator<E, T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> EnumValidator<E, T2> map(Function<? super T, ? extends T2> mapper) {
 		return new EnumValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/FloatValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/FloatValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class FloatValidator<T> extends DefaultArguments1Validator<Float, T> {
 
 	@Override
-	public <T2> FloatValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> FloatValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new FloatValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/InstantValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/InstantValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class InstantValidator<T> extends DefaultArguments1Validator<Instant, T> {
 
 	@Override
-	public <T2> InstantValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> InstantValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new InstantValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/IntegerValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/IntegerValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class IntegerValidator<T> extends DefaultArguments1Validator<Integer, T> {
 
 	@Override
-	public <T2> IntegerValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> IntegerValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new IntegerValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/LocalDateTimeValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/LocalDateTimeValidator.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 public class LocalDateTimeValidator<T> extends DefaultArguments1Validator<LocalDateTime, T> {
 
 	@Override
-	public <T2> LocalDateTimeValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> LocalDateTimeValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new LocalDateTimeValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/LocalDateValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/LocalDateValidator.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 public class LocalDateValidator<T> extends DefaultArguments1Validator<LocalDate, T> {
 
 	@Override
-	public <T2> LocalDateValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> LocalDateValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new LocalDateValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/LocalTimeValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/LocalTimeValidator.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 public class LocalTimeValidator<T> extends DefaultArguments1Validator<LocalTime, T> {
 
 	@Override
-	public <T2> LocalTimeValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> LocalTimeValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new LocalTimeValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/LongValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/LongValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class LongValidator<T> extends DefaultArguments1Validator<Long, T> {
 
 	@Override
-	public <T2> LongValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> LongValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new LongValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/ObjectValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/ObjectValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class ObjectValidator<X, T> extends DefaultArguments1Validator<X, T> {
 
 	@Override
-	public <T2> ObjectValidator<X, T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> ObjectValidator<X, T2> map(Function<? super T, ? extends T2> mapper) {
 		return new ObjectValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/OffsetDateTimeValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/OffsetDateTimeValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class OffsetDateTimeValidator<T> extends DefaultArguments1Validator<OffsetDateTime, T> {
 
 	@Override
-	public <T2> OffsetDateTimeValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> OffsetDateTimeValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new OffsetDateTimeValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/ShortValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/ShortValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class ShortValidator<T> extends DefaultArguments1Validator<Short, T> {
 
 	@Override
-	public <T2> ShortValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> ShortValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new ShortValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/StringValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/StringValidator.java
@@ -26,7 +26,7 @@ import am.ik.yavi.fn.Function1;
 public class StringValidator<T> extends DefaultArguments1Validator<String, T> {
 
 	@Override
-	public <T2> StringValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> StringValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new StringValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/YearMonthValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/YearMonthValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class YearMonthValidator<T> extends DefaultArguments1Validator<YearMonth, T> {
 
 	@Override
-	public <T2> YearMonthValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> YearMonthValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new YearMonthValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/YearValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/YearValidator.java
@@ -27,7 +27,7 @@ import am.ik.yavi.fn.Function1;
 public class YearValidator<T> extends DefaultArguments1Validator<Year, T> {
 
 	@Override
-	public <T2> YearValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> YearValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new YearValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/arguments/ZonedDateTimeValidator.java
+++ b/src/main/java/am/ik/yavi/arguments/ZonedDateTimeValidator.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 public class ZonedDateTimeValidator<T> extends DefaultArguments1Validator<ZonedDateTime, T> {
 
 	@Override
-	public <T2> ZonedDateTimeValidator<T2> andThen(Function<? super T, ? extends T2> mapper) {
+	public <T2> ZonedDateTimeValidator<T2> map(Function<? super T, ? extends T2> mapper) {
 		return new ZonedDateTimeValidator<>(super.validator, s -> mapper.apply(super.mapper.apply(s)));
 	}
 

--- a/src/main/java/am/ik/yavi/core/ValueValidator.java
+++ b/src/main/java/am/ik/yavi/core/ValueValidator.java
@@ -15,6 +15,8 @@
  */
 package am.ik.yavi.core;
 
+import am.ik.yavi.fn.Validation;
+import am.ik.yavi.jsr305.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -26,10 +28,14 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import am.ik.yavi.fn.Validation;
-import am.ik.yavi.jsr305.Nullable;
-
 /**
+ * A validator interface that validates a value of type T and transforms it into type X.
+ * This interface represents a validation process that not only validates the input but
+ * also has the capability to transform it from one type to another, returning the
+ * validated and transformed result.
+ *
+ * @param <T> the type of the object to be validated
+ * @param <X> the type of the validated and transformed result
  * @since 0.8.0
  */
 @FunctionalInterface
@@ -46,7 +52,23 @@ public interface ValueValidator<T, X> {
 		return (x, locale, constraintContext) -> Validated.of(Validation.success(x));
 	}
 
+	/**
+	 * @deprecated Use {@link #map(Function)} instead.
+	 */
+	@Deprecated
 	default <X2> ValueValidator<T, X2> andThen(Function<? super X, ? extends X2> mapper) {
+		return this.map(mapper);
+	}
+
+	/**
+	 * Maps the validated value to a new type using the provided mapper function. This is
+	 * a transformation operation that applies the function only if validation succeeds.
+	 * @param mapper function to transform the validated value
+	 * @param <X2> the type after transformation
+	 * @return a value validator that applies the mapping function after validation
+	 * @since 0.17.0
+	 */
+	default <X2> ValueValidator<T, X2> map(Function<? super X, ? extends X2> mapper) {
 		return (t, locale, constraintContext) -> ValueValidator.this.validate(t, locale, constraintContext).map(mapper);
 	}
 

--- a/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/ArgumentsValidatorTest.java
@@ -529,7 +529,7 @@ class ArgumentsValidatorTest {
 
 	@Test
 	void andThenLazy() {
-		arguments1Validator.andThen(Country::name).lazy().validated("JP");
+		arguments1Validator.map(Country::name).lazy().validated("JP");
 		arguments2Validator.andThen(range -> range.getFrom() + "-" + range.getTo()).lazy().validated(1, 2);
 		arguments3Validator.andThen(User::getName).lazy().validated("aa", "bb@cc.dd", 18);
 	}

--- a/src/test/java/am/ik/yavi/arguments/BigDecimalValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/BigDecimalValidatorTest.java
@@ -97,7 +97,7 @@ class BigDecimalValidatorTest {
 					.build(Price::new),
 				BigDecimalValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual(BigDecimal.valueOf(0)))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/BigIntegerValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/BigIntegerValidatorTest.java
@@ -97,7 +97,7 @@ class BigIntegerValidatorTest {
 					.build(Price::new),
 				BigIntegerValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual(BigInteger.valueOf(0)))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/BooleanValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/BooleanValidatorTest.java
@@ -91,7 +91,7 @@ class BooleanValidatorTest {
 
 	static Stream<BooleanValidator<Checked>> validators() {
 		return Stream.of(BooleanValidatorBuilder.of("checked", c -> c.notNull().isTrue()).build(Checked::new),
-				BooleanValidatorBuilder.of("checked", c -> c.notNull().isTrue()).build().andThen(Checked::new));
+				BooleanValidatorBuilder.of("checked", c -> c.notNull().isTrue()).build().map(Checked::new));
 	}
 
 	public static class Checked {

--- a/src/test/java/am/ik/yavi/arguments/DoubleValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/DoubleValidatorTest.java
@@ -95,7 +95,7 @@ class DoubleValidatorTest {
 				DoubleValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((double) 0)).build(Price::new),
 				DoubleValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((double) 0))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/FloatValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/FloatValidatorTest.java
@@ -94,7 +94,7 @@ class FloatValidatorTest {
 				FloatValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((float) 0)).build(Price::new),
 				FloatValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((float) 0))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/IntegerValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/IntegerValidatorTest.java
@@ -91,9 +91,7 @@ class IntegerValidatorTest {
 
 	static Stream<IntegerValidator<Price>> validators() {
 		return Stream.of(IntegerValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual(0)).build(Price::new),
-				IntegerValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual(0))
-					.build()
-					.andThen(Price::new));
+				IntegerValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual(0)).build().map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/LongValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/LongValidatorTest.java
@@ -94,7 +94,7 @@ class LongValidatorTest {
 				LongValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((long) 0)).build(Price::new),
 				LongValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((long) 0))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/ObjectValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/ObjectValidatorTest.java
@@ -117,7 +117,7 @@ class ObjectValidatorTest {
 					.build(Date::from),
 				ObjectValidatorBuilder.<Instant>of("createdAt", c -> c.notNull().predicateNullable(past))
 					.build()
-					.andThen(Date::from));
+					.map(Date::from));
 	}
 
 }

--- a/src/test/java/am/ik/yavi/arguments/ShortValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/ShortValidatorTest.java
@@ -94,7 +94,7 @@ class ShortValidatorTest {
 				ShortValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((short) 0)).build(Price::new),
 				ShortValidatorBuilder.of("price", c -> c.notNull().greaterThanOrEqual((short) 0))
 					.build()
-					.andThen(Price::new));
+					.map(Price::new));
 	}
 
 	public static class Price {

--- a/src/test/java/am/ik/yavi/arguments/StringValidatorTest.java
+++ b/src/test/java/am/ik/yavi/arguments/StringValidatorTest.java
@@ -100,7 +100,7 @@ class StringValidatorTest {
 				StringValidatorBuilder.of("country", c -> c.notBlank().greaterThanOrEqual(2)).build(Country::new),
 				StringValidatorBuilder.of("country", c -> c.notBlank().greaterThanOrEqual(2))
 					.build()
-					.andThen(Country::new));
+					.map(Country::new));
 	}
 
 }

--- a/src/test/java/am/ik/yavi/core/ApplicativeValidationTest.java
+++ b/src/test/java/am/ik/yavi/core/ApplicativeValidationTest.java
@@ -48,7 +48,7 @@ class ApplicativeValidationTest {
 	static final ValueValidator<Country, String> countryValidator = Country.validator()
 		.prefixed("country")
 		.applicative()
-		.andThen(Country::name);
+		.map(Country::name);
 
 	@ParameterizedTest
 	@MethodSource("validValidations")

--- a/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValueValidatorTest.java
@@ -79,7 +79,7 @@ class ValueValidatorTest {
 			._string(f -> f, "myLocalDate", CharSequenceConstraint::isoLocalDate)
 			.build()
 			.applicative()
-			.andThen(LocalDate::parse);
+			.map(LocalDate::parse);
 		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
 		Assertions.assertThat(localDateValidated.isValid()).isFalse();
 		Assertions.assertThat(localDateValidated.errors()).hasSize(1);
@@ -95,7 +95,7 @@ class ValueValidatorTest {
 			._string(f -> f, "myLocalDate", c -> c.localDate("dd/MM/uuuu"))
 			.build()
 			.applicative()
-			.andThen(s -> LocalDate.parse(s, DateTimeFormatter.ofPattern("dd/MM/uuuu")));
+			.map(s -> LocalDate.parse(s, DateTimeFormatter.ofPattern("dd/MM/uuuu")));
 		final Validated<LocalDate> localDateValidated = localDateValidator.validate("31/01/2022");
 		Assertions.assertThat(localDateValidated.isValid()).isTrue();
 		Assertions.assertThat(localDateValidated.value()).isEqualTo(LocalDate.of(2022, 1, 31));


### PR DESCRIPTION
- Mark andThen(Function) as deprecated
- Add new map(Function) method with same implementation
- Add @since 0.17.0 annotation
- Improve class Javadoc to better explain ValueValidator's purpose
- Keep original andThen(Function) for backward compatibility