### PR TITLE
Fix throwIfInvalid() custom message handling for null targets

### DIFF
--- a/src/main/java/am/ik/yavi/core/Validator.java
+++ b/src/main/java/am/ik/yavi/core/Validator.java
@@ -363,7 +363,13 @@ public class Validator<T> implements Validatable<T> {
 	private ConstraintViolations validate(T target, String collectionName, int index, Locale locale,
 			ConstraintContext constraintContext) {
 		if (target == null) {
-			throw new IllegalArgumentException("target must not be null");
+			// Return ConstraintViolations instead of throwing exception
+			// to allow throwIfInvalid() to handle custom messages
+			final ConstraintViolations violations = new ConstraintViolations();
+			final String name = this.prefix + this.indexedName("", collectionName, index);
+			final ConstraintViolation violation = notNullViolation(name, locale);
+			violations.add(violation);
+			return violations;
 		}
 		final ConstraintViolations violations = new ConstraintViolations();
 		for (ConstraintPredicates<T, ?> predicates : this.predicatesList) {

--- a/src/test/java/am/ik/yavi/core/ValidatorTest.java
+++ b/src/test/java/am/ik/yavi/core/ValidatorTest.java
@@ -590,6 +590,17 @@ class ValidatorTest {
 	}
 
 	@Test
+	void throwIfInValidWithCustomMessageForNullTarget() throws Exception {
+		try {
+			validator().validate(null).throwIfInvalid(v -> new IllegalArgumentException("Custom message"));
+			fail("fail");
+		}
+		catch (IllegalArgumentException e) {
+			assertThat(e.getMessage()).isEqualTo("Custom message");
+		}
+	}
+
+	@Test
 	void throwIfInValidValid() throws Exception {
 		User user = new User("foo", "foo@example.com", 30);
 		validator().validate(user).throwIfInvalid(ConstraintViolationsException::new);


### PR DESCRIPTION
## Summary

- Fixed throwIfInvalid() method to properly handle custom messages when target is null
- Previously, the validator would throw IllegalArgumentException directly for null targets, bypassing the custom message functionality
- Now returns ConstraintViolations instead of throwing exception, allowing throwIfInvalid() to handle custom messages appropriately

## Changes

- Modified Validator.validate() method to return ConstraintViolations with null violation instead of throwing exception
- Added test case to verify custom message handling for null targets