### PR TITLE
Bump the base Java version to 17 (resolves #389)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8.x, 11.x, 17.x, 21.x]
+        java: [17.x, 21.x]
     permissions:
       id-token: write
       contents: read
@@ -36,18 +36,18 @@ jobs:
         distribution: 'liberica'
         cache: maven
     - name: Unit Tests
-      if: (github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main') || !startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: (github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main') || !startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       run: ./mvnw -V test --no-transfer-progress
     - name: Unit Tests with Coverage
-      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       run: |
         ./mvnw -V jacoco:prepare-agent test jacoco:report --no-transfer-progress
     - name: Build Javadoc
-      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       run: |
         ./mvnw -V javadoc:jar --no-transfer-progress
     - name: Import Secrets
-      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       id: secrets
       uses: hashicorp/vault-action@v3.0.0
       with:
@@ -62,7 +62,7 @@ jobs:
           kv/data/cicd/gpg secring | GPG_SECRING ;
           kv/data/cicd/gpg passphrase | GPG_PASSPHRASE ;      
     - name: Deploy to sonatype-snapshots
-      if: github.ref == 'refs/heads/develop' && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: github.ref == 'refs/heads/develop' && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       run: |
         set -e
         cat > settings.xml <<EOF
@@ -90,7 +90,7 @@ jobs:
         gpg-private-key: ${{ steps.secrets.outputs.GPG_SECRING }}
         gpg-passphrase: ${{ steps.secrets.outputs.GPG_PASSPHRASE }}
     - name: Deploy to sonatype-releases
-      if: github.ref == 'refs/heads/main' && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/8')
+      if: github.ref == 'refs/heads/main' && startsWith(env.JAVA_HOME, '/opt/hostedtoolcache/Java_Liberica_jdk/17')
       run: |
         set -e
         cat > settings.xml <<EOF

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>Yet Another Validation (lambda based type safe validation)</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Resolves #389 (prerequisite for #388 and #390; also resolves #160).

## Changes
- **`pom.xml`**: `java.version` `1.8` → `17` — drives the compiler `source`/`target` and the Kotlin `jvmTarget`.
- **`.github/workflows/ci.yaml`**: CI matrix `[8.x, 11.x, 17.x, 21.x]` → `[17.x, 21.x]` (the 8.x/11.x axes can no longer compile Java-17 source), and the coverage / javadoc / snapshot / release gates move from the JDK-8 build to the JDK-17 build so published artifacts ship Java-17 bytecode.

## Verification
Migrated one LTS step at a time and ran `mvn test` at each hop:
- JDK 11 → **2104 / 2104** tests pass
- JDK 17 → **2104 / 2104** tests pass

Identical to the JDK-8 baseline (2104 / 2104). No source changes and no dependency bumps were needed — pure Java, no `--add-opens` / EE / Lombok walls, and `spring-javaformat` validates cleanly on 17.

🤖 Migrated with the [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.
